### PR TITLE
chore: mark control-plane vnc flag non-nullable

### DIFF
--- a/control-plane/openapi.control.yaml
+++ b/control-plane/openapi.control.yaml
@@ -155,7 +155,6 @@ components:
           type: string
         vnc_enabled:
           type: boolean
-          nullable: true
           description: Whether a VNC preview is available for this session.
         vnc:
           type: object


### PR DESCRIPTION
## Summary
- mark the `vnc_enabled` flag as non-nullable in the control-plane OpenAPI schema
- keep the contract aligned with the actual boolean responses expected by downstream clients

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfe9445968832aba88899748ec8293