### PR TITLE
Refactor websocket bridging into shared module

### DIFF
--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -1,0 +1,5 @@
+"""Shared utilities used by multiple Camofleet services."""
+
+from .websocket_bridge import bridge_websocket
+
+__all__ = ["bridge_websocket"]

--- a/shared/tests/test_websocket_bridge.py
+++ b/shared/tests/test_websocket_bridge.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+
+import pytest
+from fastapi import WebSocketDisconnect
+
+from shared.websocket_bridge import bridge_websocket
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class FakeWebSocket:
+    def __init__(self, messages: list[dict | BaseException]):
+        self._messages = list(messages)
+        self.sent: list[tuple[str, str | bytes]] = []
+        self.close_calls: list[tuple[int, str]] = []
+
+    async def receive(self) -> dict:
+        if not self._messages:
+            raise RuntimeError("No more messages")
+        message = self._messages.pop(0)
+        if isinstance(message, BaseException):
+            raise message
+        return message
+
+    async def send_text(self, data: str) -> None:
+        self.sent.append(("text", data))
+
+    async def send_bytes(self, data: bytes) -> None:
+        self.sent.append(("bytes", data))
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self.close_calls.append((code, reason or ""))
+
+
+class FakeUpstream:
+    def __init__(self, outgoing: list[str | bytes]):
+        self._outgoing = list(outgoing)
+        self.sent: list[str | bytes] = []
+        self.closed = False
+        self.pings: list[bytes] = []
+        self.pongs: list[bytes] = []
+
+    async def send(self, data: str | bytes) -> None:
+        self.sent.append(data)
+
+    def ping(self, data: bytes) -> asyncio.Future[None]:
+        self.pings.append(data)
+        future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+        future.set_result(None)
+        return future
+
+    async def pong(self, data: bytes) -> None:
+        self.pongs.append(data)
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> str | bytes:
+        if self._outgoing:
+            return self._outgoing.pop(0)
+        raise StopAsyncIteration
+
+
+@asynccontextmanager
+async def fake_connect(upstream: FakeUpstream):
+    yield upstream
+
+
+@pytest.mark.anyio("asyncio")
+async def test_bridge_websocket_proxies_messages() -> None:
+    websocket = FakeWebSocket(
+        [
+            {"type": "websocket.receive", "text": "hello"},
+            {"type": "websocket.receive", "bytes": b"binary"},
+            {"type": "websocket.disconnect", "code": 1000},
+        ]
+    )
+    upstream = FakeUpstream(["world", b"bytes-reply"])
+
+    await bridge_websocket(websocket, lambda: fake_connect(upstream))
+
+    assert upstream.sent == ["hello", b"binary"]
+    assert websocket.sent == [("text", "world"), ("bytes", b"bytes-reply")]
+    assert websocket.close_calls  # closed once upstream finished
+
+
+@pytest.mark.anyio("asyncio")
+async def test_bridge_websocket_handles_disconnect() -> None:
+    websocket = FakeWebSocket([WebSocketDisconnect(code=1001)])
+    upstream = FakeUpstream([])
+
+    await bridge_websocket(websocket, lambda: fake_connect(upstream))
+
+    assert upstream.closed is True
+    assert websocket.close_calls  # closed by upstream forwarder
+
+
+@pytest.mark.anyio("asyncio")
+async def test_bridge_websocket_forwards_ping_pong() -> None:
+    websocket = FakeWebSocket(
+        [
+            {"type": "websocket.receive", "ping": b"ping"},
+            {"type": "websocket.receive", "pong": b"pong"},
+            {"type": "websocket.disconnect", "code": 1000},
+        ]
+    )
+    upstream = FakeUpstream([])
+
+    await bridge_websocket(websocket, lambda: fake_connect(upstream))
+
+    assert upstream.pings == [b"ping"]
+    assert upstream.pongs == [b"pong"]

--- a/shared/websocket_bridge.py
+++ b/shared/websocket_bridge.py
@@ -1,0 +1,148 @@
+"""Utilities for proxying WebSocket traffic between services."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
+from typing import Protocol, runtime_checkable
+
+from fastapi import WebSocket, WebSocketDisconnect, status
+import websockets
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
+
+LOGGER = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class SupportsPing(Protocol):
+    def ping(self, data: bytes | None = None) -> Awaitable[object]:
+        """Send a ping frame upstream."""
+
+
+@runtime_checkable
+class SupportsPong(Protocol):
+    async def pong(self, data: bytes | None = None) -> None:
+        """Send a pong frame upstream."""
+
+
+UpstreamProtocol = websockets.WebSocketClientProtocol
+ConnectCallable = Callable[[], AbstractAsyncContextManager[UpstreamProtocol]]
+
+
+async def bridge_websocket(
+    websocket: WebSocket,
+    connect_upstream: ConnectCallable,
+    *,
+    logger: logging.Logger | None = None,
+    log_context: str = "websocket bridge",
+    error_close_code: int = status.WS_1011_INTERNAL_ERROR,
+) -> None:
+    """Stream messages bidirectionally between a FastAPI WebSocket and upstream server.
+
+    Args:
+        websocket: The WebSocket connected to the client.
+        connect_upstream: A callable returning an async context manager yielding the
+            upstream :class:`~websockets.WebSocketClientProtocol` connection.
+        logger: Optional logger used for reporting unexpected failures.
+        log_context: Human readable description included in log messages.
+        error_close_code: Close code to report to the client when unexpected
+            errors occur while proxying messages.
+    """
+
+    logger = logger or LOGGER
+    try:
+        async with connect_upstream() as upstream:
+            forward_client = asyncio.create_task(
+                _forward_client_to_upstream(websocket, upstream),
+                name=f"{log_context}-client->upstream",
+            )
+            forward_upstream = asyncio.create_task(
+                _forward_upstream_to_client(websocket, upstream),
+                name=f"{log_context}-upstream->client",
+            )
+            done, pending = await asyncio.wait(
+                {forward_client, forward_upstream},
+                return_when=asyncio.FIRST_EXCEPTION,
+            )
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            for task in done:
+                try:
+                    task.result()
+                except asyncio.CancelledError:  # pragma: no cover - propagate cancellation
+                    raise
+    except asyncio.CancelledError:  # pragma: no cover - shutdown handling
+        raise
+    except (ConnectionClosedError, ConnectionClosedOK, WebSocketDisconnect):
+        with contextlib.suppress(RuntimeError):
+            await websocket.close()
+    except Exception as exc:  # pragma: no cover - defensive logging path
+        logger.warning("%s failure: %s", log_context, exc)
+        with contextlib.suppress(RuntimeError):
+            await websocket.close(code=error_close_code)
+
+
+async def _forward_client_to_upstream(
+    websocket: WebSocket,
+    upstream: UpstreamProtocol,
+) -> None:
+    """Forward client messages to the upstream worker WebSocket."""
+
+    try:
+        while True:
+            message = await websocket.receive()
+            message_type = message.get("type")
+            if message_type == "websocket.disconnect":
+                await upstream.close()
+                break
+            if message_type != "websocket.receive":
+                continue
+            data = message.get("text")
+            if data is not None:
+                await upstream.send(data)
+                continue
+            data_bytes = message.get("bytes")
+            if data_bytes is not None:
+                await upstream.send(data_bytes)
+                continue
+            if "ping" in message:
+                _send_ping(upstream, message.get("ping"))
+                continue
+            if "pong" in message:
+                await _send_pong(upstream, message.get("pong"))
+    except WebSocketDisconnect:
+        await upstream.close()
+
+
+async def _forward_upstream_to_client(
+    websocket: WebSocket,
+    upstream: UpstreamProtocol,
+) -> None:
+    """Forward upstream worker messages to the client WebSocket."""
+
+    try:
+        async for data in upstream:
+            if isinstance(data, (bytes, bytearray)):
+                await websocket.send_bytes(data)
+            else:
+                await websocket.send_text(data)
+    finally:
+        with contextlib.suppress(RuntimeError):
+            await websocket.close()
+
+
+def _send_ping(upstream: UpstreamProtocol, data: bytes | None) -> None:
+    if isinstance(upstream, SupportsPing):
+        upstream.ping(data or b"")
+
+
+async def _send_pong(upstream: UpstreamProtocol, data: bytes | None) -> None:
+    if isinstance(upstream, SupportsPong):
+        await upstream.pong(data or b"")
+
+
+__all__ = ["bridge_websocket"]


### PR DESCRIPTION
## Summary
- add a shared websocket bridge helper that centralises proxy behaviour and ping/pong handling
- switch the control plane and worker websocket endpoints to reuse the shared bridge
- cover the bridge helper with unit tests for message forwarding, disconnects, and ping/pong events

## Testing
- PYTHONPATH=. pytest shared/tests
- PYTHONPATH=control-plane:. pytest control-plane/tests
- PYTHONPATH=worker:. pytest worker/tests

------
https://chatgpt.com/codex/tasks/task_e_68d01448ec4c832aa2184461ae187cd8