### PR TITLE
Refactor session management into modular components

### DIFF
--- a/runner/camoufox_runner/browser.py
+++ b/runner/camoufox_runner/browser.py
@@ -1,0 +1,177 @@
+"""Subprocess management helpers for launching Playwright browser servers."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import tempfile
+from asyncio import subprocess as aio_subprocess
+from typing import Any
+
+from camoufox import launch_options
+from playwright._impl._driver import compute_driver_executable
+
+LOGGER = logging.getLogger(__name__)
+
+BROWSER_SERVER_LAUNCH_TIMEOUT = 45
+
+
+class SubprocessBrowserServer:
+    """Wrap a spawned Playwright browser server process."""
+
+    def __init__(
+        self,
+        process: aio_subprocess.Process,
+        ws_endpoint: str,
+        drain_tasks: list[asyncio.Task[None]],
+    ) -> None:
+        self._process = process
+        self.ws_endpoint = ws_endpoint
+        self._drain_tasks = drain_tasks
+
+    async def close(self) -> None:
+        """Terminate the subprocess and cancel background drain tasks."""
+
+        if self._process.returncode is None:
+            self._process.terminate()
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=5)
+            except TimeoutError:
+                self._process.kill()
+                await self._process.wait()
+
+        for task in self._drain_tasks:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
+class BrowserLauncher:
+    """Create Camoufox-driven Playwright browser server subprocesses."""
+
+    def __init__(self, *, logger: logging.Logger | None = None) -> None:
+        self._logger = logger or LOGGER
+
+    async def launch(
+        self,
+        *,
+        headless: bool,
+        vnc: bool,
+        display: str | None,
+        override_proxy: dict[str, Any] | None = None,
+    ) -> SubprocessBrowserServer:
+        """Launch a new browser server configured through Camoufox."""
+
+        opts = launch_options(headless=headless)
+        env_vars = {k: v for k, v in (opts.get("env") or {}).items() if v is not None}
+        if display:
+            env_vars["DISPLAY"] = display
+        config: dict[str, Any] = {
+            "headless": headless,
+            "args": opts.get("args") or [],
+            "env": env_vars,
+        }
+        if executable_path := opts.get("executable_path"):
+            config["executablePath"] = executable_path
+        if prefs := opts.get("firefox_user_prefs"):
+            config["firefoxUserPrefs"] = prefs
+        if override_proxy:
+            config["proxy"] = override_proxy
+        elif proxy := opts.get("proxy"):
+            config["proxy"] = proxy
+        if opts.get("ignore_default_args") is not None:
+            config["ignoreDefaultArgs"] = opts["ignore_default_args"]
+
+        node_path, cli_path = compute_driver_executable()
+
+        config_path = await asyncio.to_thread(_write_launch_config, config)
+        process = await aio_subprocess.create_subprocess_exec(
+            node_path,
+            cli_path,
+            "launch-server",
+            "--browser=firefox",
+            f"--config={config_path}",
+            stdout=aio_subprocess.PIPE,
+            stderr=aio_subprocess.PIPE,
+        )
+
+        try:
+            try:
+                raw_endpoint = await asyncio.wait_for(
+                    process.stdout.readline(), timeout=BROWSER_SERVER_LAUNCH_TIMEOUT
+                )
+            except TimeoutError as exc:
+                await _terminate_process(process)
+                raise RuntimeError("Timed out launching Camoufox server") from exc
+
+            if not raw_endpoint:
+                stderr_output = await process.stderr.read()
+                return_code = await process.wait()
+                message = stderr_output.decode().strip() or "unknown error"
+                raise RuntimeError(
+                    f"Failed to launch Camoufox server (code {return_code}): {message}"
+                )
+
+            ws_endpoint = raw_endpoint.decode().strip()
+            stdout_task = asyncio.create_task(
+                _drain_stream(process.stdout, "camoufox-stdout", self._logger),
+                name="camoufox-server-stdout",
+            )
+            stderr_task = asyncio.create_task(
+                _drain_stream(process.stderr, "camoufox-stderr", self._logger),
+                name="camoufox-server-stderr",
+            )
+            return SubprocessBrowserServer(process, ws_endpoint, [stdout_task, stderr_task])
+        except Exception:
+            await _terminate_process(process, kill=True)
+            raise
+        finally:
+            await asyncio.to_thread(_remove_file, config_path)
+
+
+async def _drain_stream(
+    stream: asyncio.StreamReader | None, prefix: str, logger: logging.Logger
+) -> None:
+    """Drain subprocess output to avoid blocking pipes and log diagnostic lines."""
+
+    if stream is None:
+        return
+    while True:
+        line = await stream.readline()
+        if not line:
+            break
+        logger.debug("%s: %s", prefix, line.decode().rstrip())
+
+
+def _write_launch_config(options: dict[str, Any]) -> str:
+    with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as fh:
+        json.dump(options, fh)
+        fh.write("\n")
+        return fh.name
+
+
+def _remove_file(path: str) -> None:
+    with contextlib.suppress(FileNotFoundError):
+        import os
+
+        os.remove(path)
+
+
+async def _terminate_process(process: aio_subprocess.Process, *, kill: bool = False) -> None:
+    if process.returncode is not None:
+        return
+    if not kill:
+        process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=5)
+            return
+        except TimeoutError:
+            LOGGER.warning("Camoufox server did not exit after terminate; killing")
+    process.kill()
+    with contextlib.suppress(asyncio.TimeoutError):
+        await asyncio.wait_for(process.wait(), timeout=5)
+
+
+__all__ = ["BrowserLauncher", "SubprocessBrowserServer", "BROWSER_SERVER_LAUNCH_TIMEOUT"]

--- a/runner/camoufox_runner/cleanup.py
+++ b/runner/camoufox_runner/cleanup.py
@@ -1,0 +1,63 @@
+"""Background cleanup helpers for session TTL enforcement."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+LOGGER = logging.getLogger(__name__)
+
+
+class IdleSessionCleaner:
+    """Run periodic cleanup tasks to reap expired sessions."""
+
+    def __init__(
+        self,
+        *,
+        interval: float,
+        collect_expired: Callable[[], Awaitable[list[Any]]],
+        on_expired: Callable[[Any], Awaitable[None]],
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._interval = interval
+        self._collect_expired = collect_expired
+        self._on_expired = on_expired
+        self._logger = logger or LOGGER
+        self._task: asyncio.Task[None] | None = None
+
+    def start(self) -> None:
+        if self._task is not None:
+            return
+        self._task = asyncio.create_task(self._loop(), name="camoufox-cleanup")
+
+    async def stop(self) -> None:
+        if self._task is None:
+            return
+        self._task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+
+    async def run_once(self) -> None:
+        try:
+            handles = await self._collect_expired()
+        except Exception as exc:  # pragma: no cover - defensive
+            self._logger.warning("Failed to collect expired sessions: %s", exc)
+            return
+        for handle in handles:
+            try:
+                await self._on_expired(handle)
+            except Exception as exc:  # pragma: no cover - defensive
+                session_id = getattr(handle, "id", "<unknown>")
+                self._logger.warning("Failed to clean up session %s: %s", session_id, exc)
+
+    async def _loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._interval)
+            await self.run_once()
+
+
+__all__ = ["IdleSessionCleaner"]

--- a/runner/camoufox_runner/prewarm.py
+++ b/runner/camoufox_runner/prewarm.py
@@ -1,0 +1,138 @@
+"""Management of prewarmed browser and VNC resources."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from dataclasses import dataclass
+
+from .browser import BrowserLauncher, SubprocessBrowserServer
+from .vnc import VncProcessManager, VncSession
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class PrewarmedResource:
+    """Container holding a prewarmed browser server and optional VNC session."""
+
+    server: SubprocessBrowserServer
+    vnc_session: VncSession | None
+    headless: bool
+
+
+class PrewarmPool:
+    """Maintain reusable browser servers for faster session start-up."""
+
+    def __init__(
+        self,
+        *,
+        launcher: BrowserLauncher,
+        vnc_manager: VncProcessManager,
+        headless_target: int,
+        vnc_target: int,
+        check_interval: float,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._launcher = launcher
+        self._vnc_manager = vnc_manager
+        self._headless_target = max(0, headless_target)
+        self._vnc_target = max(0, vnc_target if vnc_manager.available else 0)
+        self._check_interval = check_interval
+        self._logger = logger or LOGGER
+        self._headless: list[PrewarmedResource] = []
+        self._vnc: list[PrewarmedResource] = []
+        self._lock = asyncio.Lock()
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Start the background loop that keeps the pool filled."""
+
+        await self.top_up_once()
+        if self._should_run_loop():
+            self._task = asyncio.create_task(self._loop(), name="camoufox-prewarm")
+
+    async def stop(self) -> None:
+        if self._task is None:
+            return
+        self._task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+
+    async def close(self) -> None:
+        """Stop the background loop and dispose prewarmed resources."""
+
+        await self.stop()
+        async with self._lock:
+            resources = list(self._headless) + list(self._vnc)
+            self._headless.clear()
+            self._vnc.clear()
+        for item in resources:
+            try:
+                await item.server.close()
+            finally:
+                await self._vnc_manager.stop_session(item.vnc_session)
+
+    async def acquire(self, *, vnc: bool, headless: bool) -> PrewarmedResource | None:
+        async with self._lock:
+            if vnc and self._vnc:
+                return self._vnc.pop()
+            if (not vnc) and headless and self._headless:
+                return self._headless.pop()
+            return None
+
+    def schedule_top_up(self) -> None:
+        if not self._should_run_loop():
+            return
+        task = asyncio.create_task(self.top_up_once(), name="camoufox-prewarm-kick")
+        task.add_done_callback(lambda _: None)
+
+    async def top_up_once(self) -> None:
+        need_headless: int
+        need_vnc: int
+        async with self._lock:
+            need_headless = max(0, self._headless_target - len(self._headless))
+            need_vnc = max(0, self._vnc_target - len(self._vnc))
+        for _ in range(need_headless):
+            try:
+                server = await self._launcher.launch(headless=True, vnc=False, display=None)
+                resource = PrewarmedResource(server=server, vnc_session=None, headless=True)
+                async with self._lock:
+                    self._headless.append(resource)
+            except Exception as exc:  # pragma: no cover - defensive
+                self._logger.warning("Failed to prewarm headless server: %s", exc)
+                break
+        for _ in range(need_vnc):
+            vnc_session: VncSession | None = None
+            try:
+                vnc_session = await self._vnc_manager.start_session()
+                server = await self._launcher.launch(
+                    headless=False,
+                    vnc=True,
+                    display=vnc_session.display,
+                )
+                resource = PrewarmedResource(server=server, vnc_session=vnc_session, headless=False)
+                async with self._lock:
+                    self._vnc.append(resource)
+            except Exception as exc:  # pragma: no cover - defensive
+                self._logger.warning("Failed to prewarm VNC server: %s", exc)
+                if vnc_session is not None:
+                    with contextlib.suppress(Exception):
+                        await self._vnc_manager.stop_session(vnc_session)
+                break
+
+    def _should_run_loop(self) -> bool:
+        return self._headless_target > 0 or self._vnc_target > 0
+
+    async def _loop(self) -> None:
+        while True:
+            try:
+                await self.top_up_once()
+            except Exception as exc:  # pragma: no cover - defensive
+                self._logger.warning("Prewarm loop error: %s", exc)
+            await asyncio.sleep(self._check_interval)
+
+
+__all__ = ["PrewarmPool", "PrewarmedResource"]

--- a/runner/camoufox_runner/vnc.py
+++ b/runner/camoufox_runner/vnc.py
@@ -1,0 +1,374 @@
+"""Management of virtual display (VNC) subprocess chains."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import shutil
+from asyncio import subprocess as aio_subprocess
+from collections import deque
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlencode, urlparse, urlunparse
+
+from .config import RunnerSettings
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class VncSlot:
+    """Tuple representing one reserved display slot and networking ports."""
+
+    display: int
+    vnc_port: int
+    ws_port: int
+
+
+@dataclass(slots=True)
+class VncSession:
+    """Runtime information for a launched VNC toolchain."""
+
+    slot: VncSlot
+    display: str
+    http_url: str | None
+    ws_url: str | None
+    processes: list[aio_subprocess.Process]
+    drain_tasks: list[asyncio.Task[None]] = field(default_factory=list)
+
+
+class VNCUnavailableError(RuntimeError):
+    """Raised when VNC-specific operations are requested but tooling is absent."""
+
+
+class VncResourcePool:
+    """Track and allocate VNC display/port tuples across concurrent sessions."""
+
+    def __init__(
+        self, *, displays: Iterable[int], vnc_ports: Iterable[int], ws_ports: Iterable[int]
+    ) -> None:
+        self._display_pool = deque(displays)
+        self._vnc_ports = deque(vnc_ports)
+        self._ws_ports = deque(ws_ports)
+        self._active: set[VncSlot] = set()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> VncSlot:
+        async with self._lock:
+            if not self._display_pool or not self._vnc_ports or not self._ws_ports:
+                raise RuntimeError("No available VNC slots")
+            slot = VncSlot(
+                display=self._display_pool.popleft(),
+                vnc_port=self._vnc_ports.popleft(),
+                ws_port=self._ws_ports.popleft(),
+            )
+            self._active.add(slot)
+            return slot
+
+    async def release(self, slot: VncSlot | None) -> None:
+        if slot is None:
+            return
+        async with self._lock:
+            if slot not in self._active:
+                return
+            self._active.remove(slot)
+            self._display_pool.append(slot.display)
+            self._vnc_ports.append(slot.vnc_port)
+            self._ws_ports.append(slot.ws_port)
+
+
+class VncProcessManager:
+    """Start and stop VNC-related subprocesses for sessions."""
+
+    def __init__(self, settings: RunnerSettings, *, logger: logging.Logger | None = None) -> None:
+        self._settings = settings
+        self._logger = logger or LOGGER
+        self._pool = VncResourcePool(
+            displays=range(settings.vnc_display_min, settings.vnc_display_max + 1),
+            vnc_ports=range(settings.vnc_port_min, settings.vnc_port_max + 1),
+            ws_ports=range(settings.vnc_ws_port_min, settings.vnc_ws_port_max + 1),
+        )
+        self._available = all(shutil.which(cmd) for cmd in ("Xvfb", "x11vnc", "websockify"))
+        if not self._available:
+            self._logger.info("VNC tooling not available; disabling VNC support")
+
+    @property
+    def available(self) -> bool:
+        return self._available
+
+    async def start_session(self) -> VncSession:
+        if not self._available:
+            raise VNCUnavailableError("VNC is not supported on this runner")
+
+        slot = await self._pool.acquire()
+        display_name = f":{slot.display}"
+        processes: list[aio_subprocess.Process] = []
+        drain_tasks: list[asyncio.Task[None]] = []
+        assets_path = self._settings.vnc_web_assets_path
+        try:
+            self._logger.debug(
+                "Allocating VNC slot display=%s vnc_port=%s ws_port=%s",
+                display_name,
+                slot.vnc_port,
+                slot.ws_port,
+            )
+            xvfb_proc, xvfb_tasks = await self._spawn_process(
+                [
+                    "Xvfb",
+                    display_name,
+                    "-screen",
+                    "0",
+                    self._settings.vnc_resolution,
+                    "+extension",
+                    "RANDR",
+                    "-nolisten",
+                    "tcp",
+                ],
+                name=f"vnc-xvfb:{slot.display}",
+            )
+            processes.append(xvfb_proc)
+            drain_tasks.extend(xvfb_tasks)
+            await self._wait_for_display_socket(slot, xvfb_proc)
+
+            x11vnc_cmd = [
+                "x11vnc",
+                "-display",
+                display_name,
+                "-shared",
+                "-forever",
+                "-rfbport",
+                str(slot.vnc_port),
+                "-localhost",
+                "-nopw",
+                "-quiet",
+            ]
+            x11vnc_proc, x11vnc_tasks = await self._spawn_process(
+                x11vnc_cmd,
+                name=f"vnc-x11vnc:{slot.display}",
+            )
+            processes.append(x11vnc_proc)
+            drain_tasks.extend(x11vnc_tasks)
+
+            websockify_cmd: list[str] = ["websockify"]
+            if assets_path and os.path.isdir(assets_path):
+                websockify_cmd.append(f"--web={assets_path}")
+            websockify_cmd.extend([
+                str(slot.ws_port),
+                f"127.0.0.1:{slot.vnc_port}",
+            ])
+            websockify_proc, websockify_tasks = await self._spawn_process(
+                websockify_cmd,
+                name=f"vnc-websockify:{slot.ws_port}",
+            )
+            processes.append(websockify_proc)
+            drain_tasks.extend(websockify_tasks)
+            await self._wait_for_port("127.0.0.1", slot.ws_port, websockify_proc)
+
+            http_url = self._compose_public_url(
+                self._settings.vnc_http_base,
+                slot.ws_port,
+                "/vnc.html",
+                query_params={"path": "websockify"},
+            )
+            ws_url = self._compose_public_url(
+                self._settings.vnc_ws_base,
+                slot.ws_port,
+                "/websockify",
+            )
+
+            return VncSession(
+                slot=slot,
+                display=display_name,
+                http_url=http_url,
+                ws_url=ws_url,
+                processes=processes,
+                drain_tasks=drain_tasks,
+            )
+        except Exception:
+            await self._terminate_vnc_processes(processes, drain_tasks)
+            await self._pool.release(slot)
+            raise
+
+    async def stop_session(self, session: VncSession | None) -> None:
+        if not session:
+            return
+        try:
+            await self._terminate_vnc_processes(session.processes, session.drain_tasks)
+        finally:
+            await self._pool.release(session.slot)
+
+    async def _terminate_vnc_processes(
+        self,
+        processes: list[aio_subprocess.Process],
+        drain_tasks: list[asyncio.Task[None]],
+    ) -> None:
+        for process in reversed(processes):
+            with contextlib.suppress(Exception):
+                await _terminate_process(process, kill=True)
+        for task in drain_tasks:
+            task.cancel()
+        for task in drain_tasks:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        processes.clear()
+        drain_tasks.clear()
+
+    def _compose_public_url(
+        self,
+        base: str | None,
+        port: int,
+        path_suffix: str,
+        *,
+        query_params: dict[str, str] | None = None,
+    ) -> str | None:
+        if not base:
+            return None
+        try:
+            parsed = urlparse(base)
+        except ValueError:
+            self._logger.warning("Invalid VNC base URL: %s", base)
+            return None
+        scheme = parsed.scheme or ("https" if path_suffix.endswith(".html") else "ws")
+        hostname = parsed.hostname or parsed.netloc
+        if not hostname:
+            self._logger.warning("Unable to determine hostname for VNC base URL: %s", base)
+            return None
+        userinfo = ""
+        if parsed.username:
+            userinfo = parsed.username
+            if parsed.password:
+                userinfo += f":{parsed.password}"
+            userinfo += "@"
+        if ":" in hostname and not hostname.startswith("["):
+            host_part = f"[{hostname}]"
+        else:
+            host_part = hostname
+        netloc = f"{userinfo}{host_part}:{port}"
+        base_path = parsed.path.rstrip("/")
+        combined_path = f"{base_path}{path_suffix}" if path_suffix else base_path or "/"
+        if not combined_path.startswith("/"):
+            combined_path = f"/{combined_path}"
+        query = urlencode(query_params) if query_params else ""
+        return urlunparse((scheme, netloc, combined_path, "", query, ""))
+
+    async def _wait_for_display_socket(
+        self, slot: VncSlot, process: aio_subprocess.Process
+    ) -> None:
+        socket_path = f"/tmp/.X11-unix/X{slot.display}"
+        deadline = asyncio.get_running_loop().time() + self._settings.vnc_startup_timeout_seconds
+        while True:
+            if os.path.exists(socket_path):
+                return
+            if process.returncode is not None:
+                raise RuntimeError(f"Xvfb exited with code {process.returncode}")
+            if asyncio.get_running_loop().time() >= deadline:
+                raise RuntimeError(f"Timed out waiting for Xvfb display {slot.display}")
+            await asyncio.sleep(0.05)
+
+    async def _wait_for_port(
+        self,
+        host: str,
+        port: int,
+        process: aio_subprocess.Process,
+    ) -> None:
+        deadline = asyncio.get_running_loop().time() + self._settings.vnc_startup_timeout_seconds
+        while True:
+            try:
+                reader, writer = await asyncio.open_connection(host, port)
+            except OSError as exc:
+                if process.returncode is not None:
+                    raise RuntimeError(f"websockify exited with code {process.returncode}") from exc
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise RuntimeError(
+                        f"Timed out waiting for websockify on {host}:{port}"
+                    ) from None
+                await asyncio.sleep(0.1)
+                continue
+            else:
+                writer.close()
+                with contextlib.suppress(Exception):
+                    await writer.wait_closed()
+                return
+
+    async def _spawn_process(
+        self,
+        args: list[str],
+        *,
+        name: str,
+        env: dict[str, str] | None = None,
+    ) -> tuple[aio_subprocess.Process, list[asyncio.Task[None]]]:
+        self._logger.debug("Starting %s with args: %s", name, args)
+        process = await aio_subprocess.create_subprocess_exec(
+            *args,
+            stdout=aio_subprocess.PIPE,
+            stderr=aio_subprocess.PIPE,
+            env=env,
+        )
+        tasks: list[asyncio.Task[None]] = []
+        if process.stdout is not None:
+            tasks.append(
+                asyncio.create_task(
+                    _drain_stream(process.stdout, f"{name}-stdout", self._logger),
+                    name=f"{name}-stdout",
+                )
+            )
+        if process.stderr is not None:
+            tasks.append(
+                asyncio.create_task(
+                    _drain_stream(process.stderr, f"{name}-stderr", self._logger),
+                    name=f"{name}-stderr",
+                )
+            )
+        return process, tasks
+
+
+async def _drain_stream(
+    stream: asyncio.StreamReader | None, prefix: str, logger: logging.Logger
+) -> None:
+    if stream is None:
+        return
+    while True:
+        line = await stream.readline()
+        if not line:
+            break
+        logger.debug("%s: %s", prefix, line.decode().rstrip())
+
+
+async def _terminate_process(process: aio_subprocess.Process, *, kill: bool = False) -> None:
+    if process.returncode is not None:
+        return
+    if not kill:
+        process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=5)
+            return
+        except TimeoutError:
+            LOGGER.warning("Process did not exit after terminate; killing")
+    process.kill()
+    with contextlib.suppress(asyncio.TimeoutError):
+        await asyncio.wait_for(process.wait(), timeout=5)
+
+
+def build_vnc_payload(session: VncSession | None, *, enabled: bool) -> dict[str, Any]:
+    """Return serialized VNC connection info for API responses."""
+
+    if not enabled or not session:
+        return {"ws": None, "http": None, "password_protected": False}
+    return {
+        "ws": session.ws_url,
+        "http": session.http_url,
+        "password_protected": False,
+    }
+
+
+__all__ = [
+    "VNCUnavailableError",
+    "VncProcessManager",
+    "VncResourcePool",
+    "VncSession",
+    "VncSlot",
+    "build_vnc_payload",
+]

--- a/runner/tests/test_session_components.py
+++ b/runner/tests/test_session_components.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import pytest
+
+from camoufox_runner.cleanup import IdleSessionCleaner
+from camoufox_runner.prewarm import PrewarmPool
+from camoufox_runner.vnc import VncSession, VncSlot
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class _StubServer:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.ws_endpoint = f"ws://{name}"
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _StubLauncher:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.servers: list[_StubServer] = []
+
+    async def launch(self, *, headless: bool, vnc: bool, display: str | None, **_: object) -> _StubServer:
+        server = _StubServer(f"server-{len(self.servers)}")
+        self.calls.append({"headless": headless, "vnc": vnc, "display": display})
+        self.servers.append(server)
+        return server
+
+
+class _StubVncManager:
+    def __init__(self) -> None:
+        self.available = True
+        self.started: list[VncSession] = []
+        self.stopped: list[VncSession | None] = []
+        self._counter = 0
+
+    async def start_session(self) -> VncSession:
+        slot = VncSlot(display=100 + self._counter, vnc_port=5900 + self._counter, ws_port=6900 + self._counter)
+        session = VncSession(
+            slot=slot,
+            display=f":{slot.display}",
+            http_url="http://example/vnc",
+            ws_url="ws://example/websockify",
+            processes=[],
+            drain_tasks=[],
+        )
+        self._counter += 1
+        self.started.append(session)
+        return session
+
+    async def stop_session(self, session: VncSession | None) -> None:
+        self.stopped.append(session)
+
+
+@pytest.mark.anyio
+async def test_prewarm_pool_replenishes_resources() -> None:
+    launcher = _StubLauncher()
+    vnc_manager = _StubVncManager()
+    pool = PrewarmPool(
+        launcher=launcher,
+        vnc_manager=vnc_manager,
+        headless_target=1,
+        vnc_target=1,
+        check_interval=0.01,
+    )
+
+    await pool.start()
+    # Initial fill happens during start()
+    first_headless = await pool.acquire(vnc=False, headless=True)
+    first_vnc = await pool.acquire(vnc=True, headless=False)
+    assert first_headless is not None
+    assert first_vnc is not None
+    assert first_vnc.vnc_session in vnc_manager.started
+
+    pool.schedule_top_up()
+    await asyncio.sleep(0.05)
+
+    second_headless = await pool.acquire(vnc=False, headless=True)
+    assert second_headless is not None
+
+    # Pretend the caller consumed the prewarmed resources for real sessions.
+    await first_headless.server.close()
+    await vnc_manager.stop_session(None)
+    await first_vnc.server.close()
+    await vnc_manager.stop_session(first_vnc.vnc_session)
+    await second_headless.server.close()
+    await vnc_manager.stop_session(None)
+
+    await pool.close()
+
+    assert all(server.closed for server in launcher.servers)
+    assert any(session is None for session in vnc_manager.stopped)
+    assert any(session is not None for session in vnc_manager.stopped)
+
+
+@dataclass
+class _Handle:
+    id: str
+
+
+@pytest.mark.anyio
+async def test_idle_session_cleaner_runs_once_and_background_loop() -> None:
+    expired_handles = [_Handle("one"), _Handle("two")]
+    seen: list[str] = []
+
+    async def collect() -> list[_Handle]:
+        return list(expired_handles)
+
+    async def on_expired(handle: _Handle) -> None:
+        seen.append(handle.id)
+
+    cleaner = IdleSessionCleaner(interval=0.01, collect_expired=collect, on_expired=on_expired)
+
+    await cleaner.run_once()
+    assert seen == ["one", "two"]
+
+    # Ensure the background loop schedules cleanups as well
+    seen.clear()
+    cleaner.start()
+    await asyncio.sleep(0.03)
+    await cleaner.stop()
+
+    assert seen.count("one") >= 1
+    assert seen.count("two") >= 1


### PR DESCRIPTION
## Summary
- extract dedicated browser, VNC, prewarm, and cleanup helpers and compose them from the session manager
- update session orchestration documentation/comments to describe the new architecture
- add focused async tests covering the prewarm pool and idle cleanup logic

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0821d32d0832abcf4399303ec6d93