### PR TITLE
Reuse worker HTTP clients and close on shutdown

### DIFF
--- a/control-plane/camofleet_control/main.py
+++ b/control-plane/camofleet_control/main.py
@@ -39,7 +39,7 @@ from .models import (
     SessionDescriptor,
     WorkerStatus,
 )
-from .service import worker_client
+from .service import aclose_worker_clients, worker_client
 
 LOGGER = logging.getLogger(__name__)
 
@@ -152,6 +152,10 @@ def create_app(settings: ControlSettings | None = None) -> FastAPI:
 
     def get_state(request: Request) -> AppState:
         return get_app_state(request.app)
+
+    @app.on_event("shutdown")
+    async def close_worker_clients() -> None:
+        await aclose_worker_clients()
 
     @app.get("/health")
     async def health(state: AppState = Depends(get_state)) -> dict:

--- a/control-plane/camofleet_control/service.py
+++ b/control-plane/camofleet_control/service.py
@@ -2,20 +2,68 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
+from typing import AsyncIterator
 
 import httpx
 
 from .config import ControlSettings, WorkerConfig
 
+_CLIENTS: dict[tuple[str, str], httpx.AsyncClient] = {}
+_LOCK: asyncio.Lock | None = None
+
+
+def _worker_key(worker: WorkerConfig) -> tuple[str, str]:
+    """Return a stable key for identifying worker clients."""
+
+    return (worker.name, worker.url)
+
+
+async def _get_lock() -> asyncio.Lock:
+    """Return a module level lock, creating it on demand."""
+
+    global _LOCK
+    if _LOCK is None:
+        _LOCK = asyncio.Lock()
+    return _LOCK
+
+
+async def _get_or_create_http_client(
+    worker: WorkerConfig, settings: ControlSettings
+) -> httpx.AsyncClient:
+    """Return a cached :class:`httpx.AsyncClient` for the worker."""
+
+    key = _worker_key(worker)
+    lock = await _get_lock()
+    async with lock:
+        client = _CLIENTS.get(key)
+        if client is None or client.is_closed:
+            client = httpx.AsyncClient(
+                base_url=worker.url,
+                timeout=settings.request_timeout,
+            )
+            _CLIENTS[key] = client
+        return client
+
 
 class WorkerClient:
-    """A reusable async HTTP client that targets a worker."""
+    """A thin wrapper around a shared async HTTP client for a worker.
 
-    def __init__(self, worker: WorkerConfig, settings: ControlSettings) -> None:
+    The underlying :class:`httpx.AsyncClient` is created once per
+    :class:`WorkerConfig` and cached until the application shuts down.
+    See :func:`aclose_worker_clients` for the lifecycle management hook.
+    """
+
+    def __init__(self, worker: WorkerConfig, http_client: httpx.AsyncClient) -> None:
         self.worker = worker
-        self._settings = settings
-        self._client = httpx.AsyncClient(base_url=worker.url, timeout=settings.request_timeout)
+        self._client = http_client
+
+    @property
+    def http_client(self) -> httpx.AsyncClient:
+        """Expose the underlying HTTP client for introspection in tests."""
+
+        return self._client
 
     async def health(self) -> httpx.Response:
         return await self._client.get("/health")
@@ -35,17 +83,29 @@ class WorkerClient:
     async def touch_session(self, session_id: str) -> httpx.Response:
         return await self._client.post(f"/sessions/{session_id}/touch")
 
-    async def close(self) -> None:
-        await self._client.aclose()
-
 
 @asynccontextmanager
-async def worker_client(worker: WorkerConfig, settings: ControlSettings):
-    client = WorkerClient(worker, settings)
-    try:
-        yield client
-    finally:
-        await client.close()
+async def worker_client(
+    worker: WorkerConfig, settings: ControlSettings
+) -> AsyncIterator[WorkerClient]:
+    """Yield a :class:`WorkerClient` backed by a shared HTTP connection."""
+
+    client = WorkerClient(worker, await _get_or_create_http_client(worker, settings))
+    yield client
 
 
-__all__ = ["WorkerClient", "worker_client"]
+async def aclose_worker_clients() -> None:
+    """Close all cached worker HTTP clients.
+
+    This should be invoked during the application's shutdown sequence to ensure
+    that all shared :class:`httpx.AsyncClient` instances are properly closed.
+    """
+
+    lock = await _get_lock()
+    async with lock:
+        clients = list(_CLIENTS.values())
+        _CLIENTS.clear()
+    await asyncio.gather(*(client.aclose() for client in clients), return_exceptions=True)
+
+
+__all__ = ["WorkerClient", "worker_client", "aclose_worker_clients"]

--- a/control-plane/tests/test_service.py
+++ b/control-plane/tests/test_service.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+from camofleet_control.config import ControlSettings, WorkerConfig
+from camofleet_control.main import create_app
+from camofleet_control.service import (
+    aclose_worker_clients,
+    worker_client,
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_worker_client_reuses_http_client() -> None:
+    worker = WorkerConfig(name="shared", url="http://shared")
+    settings = ControlSettings(workers=[worker])
+
+    async with worker_client(worker, settings) as first:
+        async with worker_client(worker, settings) as second:
+            assert first.http_client is second.http_client
+
+    await aclose_worker_clients()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_worker_clients_closed_on_shutdown() -> None:
+    worker = WorkerConfig(name="shutdown", url="http://shutdown")
+    settings = ControlSettings(workers=[worker])
+    app = create_app(settings)
+
+    await app.router.startup()
+    async with worker_client(worker, settings) as client:
+        http_client = client.http_client
+
+    assert not http_client.is_closed
+
+    await app.router.shutdown()
+
+    assert http_client.is_closed
+
+    await aclose_worker_clients()


### PR DESCRIPTION
## Summary
- reuse a single httpx.AsyncClient per worker and document its lifecycle
- register a FastAPI shutdown hook to close cached worker clients
- add tests confirming clients are reused across calls and closed on shutdown

## Testing
- PYTHONPATH=.:.. pytest


------
https://chatgpt.com/codex/tasks/task_e_68d084be2e64832aaa10e1dff49506d5