### PR TITLE
Ensure session touch endpoint returns full details

### DIFF
--- a/control-plane/tests/test_sessions.py
+++ b/control-plane/tests/test_sessions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
+from typing import Any
 
 import pytest
 from camofleet_control.config import ControlSettings, WorkerConfig
@@ -15,11 +16,11 @@ def anyio_backend() -> str:
 
 
 class FakeResponse:
-    def __init__(self, payload: list[dict]):
+    def __init__(self, payload: Any):
         self._payload = payload
         self.status_code = 200
 
-    def json(self) -> list[dict]:
+    def json(self) -> Any:
         return self._payload
 
     def raise_for_status(self) -> None:  # pragma: no cover - matching httpx API
@@ -87,3 +88,59 @@ async def test_list_sessions_merges_results_independent_of_completion_order(monk
     payload = resp.json()
     assert {item["worker"] for item in payload} == {"slow", "fast"}
     assert {item["id"] for item in payload} == {"a", "b"}
+
+
+@pytest.mark.anyio("asyncio")
+async def test_touch_session_returns_full_descriptor(monkeypatch) -> None:
+    worker = WorkerConfig(name="alpha", url="http://alpha", supports_vnc=True)
+    settings = ControlSettings(workers=[worker])
+    app = create_app(settings)
+
+    payload = {
+        "id": "sess-1",
+        "status": "READY",
+        "created_at": "2024-01-01T00:00:00Z",
+        "last_seen_at": "2024-01-01T00:05:00Z",
+        "browser": "camoufox",
+        "headless": False,
+        "idle_ttl_seconds": 300,
+        "labels": {"team": "qa"},
+        "worker_id": "worker-alpha",
+        "vnc_enabled": True,
+        "ws_endpoint": "/sessions/sess-1/ws",
+        "vnc": {
+            "ws": "ws://alpha/vnc",
+            "http": "http://alpha/vnc",
+            "password_protected": False,
+        },
+        "start_url_wait": "load",
+    }
+
+    class TouchClient:
+        def __init__(self, data: dict[str, Any]) -> None:
+            self._data = data
+
+        async def touch_session(self, session_id: str) -> FakeResponse:
+            assert session_id == self._data["id"]
+            return FakeResponse(self._data)
+
+    @asynccontextmanager
+    async def fake_worker_client(worker_config: WorkerConfig, _settings: ControlSettings):
+        assert worker_config.name == worker.name
+        yield TouchClient(payload)
+
+    monkeypatch.setattr("camofleet_control.main.worker_client", fake_worker_client)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post(f"/sessions/{worker.name}/{payload['id']}/touch")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == payload["id"]
+    assert body["worker"] == worker.name
+    assert body["ws_endpoint"] == f"/sessions/{worker.name}/{payload['id']}/ws"
+    assert body["vnc"] == payload["vnc"]
+    assert body["vnc_enabled"] is True
+    assert body["browser"] == payload["browser"]
+    assert body["last_seen_at"] == payload["last_seen_at"]

--- a/runner/camoufox_runner/main.py
+++ b/runner/camoufox_runner/main.py
@@ -141,7 +141,7 @@ def create_app(settings: RunnerSettings | None = None) -> FastAPI:
         handle = await manager.touch(session_id)
         if not handle:
             raise HTTPException(status_code=404, detail="Session not found")
-        return handle.detail(manager.ws_endpoint_for(handle), manager._build_vnc_payload(handle))
+        return manager.detail_for(handle)
 
     @app.get(cfg.metrics_endpoint)
     async def metrics(state: AppState = Depends(get_state)) -> Response:

--- a/worker/tests/test_worker.py
+++ b/worker/tests/test_worker.py
@@ -129,6 +129,13 @@ def test_touch_session_updates_last_seen(stub_app: TestClient) -> None:
     assert response.status_code == 200
     body = response.json()
     assert body["last_seen_at"] == "2024-01-01T00:05:00Z"
+    assert body["browser"] == "camoufox"
+    assert body["ws_endpoint"].endswith("/sess-1/ws")
+    assert body["vnc"] == {
+        "ws": None,
+        "http": None,
+        "password_protected": False,
+    }
 
 
 def test_delete_session_removes_from_store(stub_app: TestClient) -> None:


### PR DESCRIPTION
## Summary
- use the public SessionManager.detail_for helper when rendering runner touch responses
- verify the worker touch endpoint returns browser/VNC/websocket fields
- cover the control-plane touch endpoint with a success-path test that checks descriptor fields

## Testing
- pytest worker/tests/test_worker.py control-plane/tests/test_sessions.py

------
https://chatgpt.com/codex/tasks/task_e_68d0920649d4832abf568580ec966752