### PR TITLE
Reset error state after successful polling

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -95,6 +95,7 @@ export default function App(): JSX.Element {
         ]);
         setWorkers(workerData);
         setSessions(sessionData);
+        setError(null);
       } catch (err) {
         setError(err instanceof Error ? err.message : String(err));
       }

--- a/ui/src/__tests__/App.test.tsx
+++ b/ui/src/__tests__/App.test.tsx
@@ -1,0 +1,85 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import App from '../App';
+import type { SessionItem, WorkerStatus } from '../api';
+
+const { fetchWorkersMock, fetchSessionsMock } = vi.hoisted(() => ({
+  fetchWorkersMock: vi.fn<[], Promise<WorkerStatus[]>>(),
+  fetchSessionsMock: vi.fn<[], Promise<SessionItem[]>>(),
+}));
+
+vi.mock('../api', () => ({
+  fetchWorkers: fetchWorkersMock,
+  fetchSessions: fetchSessionsMock,
+  createSession: vi.fn(),
+  deleteSession: vi.fn(),
+  touchSession: vi.fn(),
+}));
+
+describe('App polling behaviour', () => {
+  const flushPromises = async () => {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  };
+
+  beforeAll(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchWorkersMock.mockReset();
+    fetchSessionsMock.mockReset();
+
+    const workers: WorkerStatus[] = [
+      { name: 'alpha', healthy: true, detail: {}, supports_vnc: true },
+    ];
+    const sessions: SessionItem[] = [];
+
+    fetchWorkersMock.mockImplementationOnce(() => Promise.reject(new Error('Network down')));
+    fetchSessionsMock.mockImplementationOnce(() => Promise.reject(new Error('Network down')));
+    fetchWorkersMock.mockImplementation(() => Promise.resolve(workers));
+    fetchSessionsMock.mockImplementation(() => Promise.resolve(sessions));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('clears stale error after successful polling cycle', async () => {
+    render(<App />);
+
+    await flushPromises();
+    expect(screen.getByText('Network down')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    await flushPromises();
+
+    expect(fetchWorkersMock).toHaveBeenCalledTimes(2);
+    expect(fetchSessionsMock).toHaveBeenCalledTimes(2);
+
+    await flushPromises();
+
+    expect(screen.queryByText('Network down')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- clear the global error state once worker/session polling succeeds to avoid stale messages
- add an App polling test that mocks API calls and verifies the error banner disappears after the next tick

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d094f468cc832aab1d9e39dd289bed