### PR TITLE
Reset selected worker when unavailable

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -123,6 +123,20 @@ export default function App(): JSX.Element {
     [workers],
   );
 
+  const selectableWorkerNames = useMemo(
+    () =>
+      healthyWorkers
+        .filter((worker) => !form.vnc || worker.supports_vnc)
+        .map((worker) => worker.name),
+    [healthyWorkers, form.vnc],
+  );
+
+  useEffect(() => {
+    if (!form.worker) return;
+    if (selectableWorkerNames.includes(form.worker)) return;
+    setForm((prev) => ({ ...prev, worker: undefined }));
+  }, [form.worker, selectableWorkerNames]);
+
   const selectedSession = useMemo(
     () => sessions.find((item) => sessionKey(item) === selectedKey) ?? null,
     [sessions, selectedKey],


### PR DESCRIPTION
## Summary
- reset the launch form worker selection when the previously chosen worker is no longer available
- add an App test that verifies the worker dropdown falls back to Auto after polling removes the selected worker

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d097d52558832a9ab5f01dd61f087f