### PR TITLE
Copy shared package and version into service images

### DIFF
--- a/docker/Dockerfile.control
+++ b/docker/Dockerfile.control
@@ -9,7 +9,10 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN pip install --no-cache-dir --upgrade pip
 
 WORKDIR /opt/app
+COPY shared /opt/shared
+COPY VERSION /opt/VERSION
 COPY control-plane /opt/app
+ENV PYTHONPATH=/opt/shared
 
 ARG INSTALL_MODE=release
 RUN if [ "$INSTALL_MODE" = "dev" ]; then \

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -30,7 +30,10 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed typing
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 WORKDIR /opt/app
+COPY shared /opt/shared
+COPY VERSION /opt/VERSION
 COPY runner /opt/app
+ENV PYTHONPATH=/opt/shared
 RUN pip install --no-cache-dir --break-system-packages -e .
 
 # Pre-fetch Camoufox resources under the pwuser cache

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -5,7 +5,10 @@ ENV PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/app
+COPY shared /opt/shared
+COPY VERSION /opt/VERSION
 COPY worker /opt/app
+ENV PYTHONPATH=/opt/shared
 
 ARG INSTALL_MODE=release
 RUN pip install --no-cache-dir --upgrade pip && \


### PR DESCRIPTION
## Summary
- copy the shared package and VERSION file into the runner, worker, and control service images
- expose the shared code via PYTHONPATH so services can import shared modules at runtime

## Testing
- `docker compose -f docker-compose.dev.yml up --build` *(fails: docker is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ee7b5738832a8c999ed0a20fd26e