### PR TITLE
Fix shared package availability in service containers

### DIFF
--- a/docker/Dockerfile.control
+++ b/docker/Dockerfile.control
@@ -12,7 +12,7 @@ WORKDIR /opt/app
 COPY shared /opt/shared
 COPY VERSION /opt/VERSION
 COPY control-plane /opt/app
-ENV PYTHONPATH=/opt/shared
+ENV PYTHONPATH=/opt
 
 ARG INSTALL_MODE=release
 RUN if [ "$INSTALL_MODE" = "dev" ]; then \

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -33,7 +33,7 @@ WORKDIR /opt/app
 COPY shared /opt/shared
 COPY VERSION /opt/VERSION
 COPY runner /opt/app
-ENV PYTHONPATH=/opt/shared
+ENV PYTHONPATH=/opt
 RUN pip install --no-cache-dir --break-system-packages -e .
 
 # Pre-fetch Camoufox resources under the pwuser cache

--- a/docker/Dockerfile.runner-vnc
+++ b/docker/Dockerfile.runner-vnc
@@ -32,7 +32,10 @@ RUN pip install --no-cache-dir --break-system-packages --ignore-installed typing
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 WORKDIR /opt/app
+COPY shared /opt/shared
+COPY VERSION /opt/VERSION
 COPY runner /opt/app
+ENV PYTHONPATH=/opt
 RUN pip install --no-cache-dir --break-system-packages -e .
 
 RUN mkdir -p /data/artifacts /data/userdata /data/tmp /home/pwuser/.cache && \

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -8,7 +8,7 @@ WORKDIR /opt/app
 COPY shared /opt/shared
 COPY VERSION /opt/VERSION
 COPY worker /opt/app
-ENV PYTHONPATH=/opt/shared
+ENV PYTHONPATH=/opt
 
 ARG INSTALL_MODE=release
 RUN pip install --no-cache-dir --upgrade pip && \


### PR DESCRIPTION
## Summary
- point PYTHONPATH to /opt so the shared package can be imported from /opt/shared
- include the shared utilities and version metadata in the VNC runner image

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d10b5aa9e8832aa38241c8ecf34733