### PR TITLE
Support dynamic VNC endpoint overrides

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,5 +20,7 @@ WORKER_RUNNER_BASE_URL=http://runner:8070
 # url         — адрес API воркера.
 # supports_vnc — воркер умеет работать с VNC-сессиями (true/false).
 # vnc_ws      — базовый WS URL для live-предпросмотра (обязателен при supports_vnc=true).
+#               Поддерживает плейсхолдеры {host} и {port}.
 # vnc_http    — HTTP URL к noVNC iframe (опционально, если нужен проксированный доступ).
-CONTROL_WORKERS=[{"name":"worker-headless","url":"http://worker-headless:8080","supports_vnc":false},{"name":"worker-vnc","url":"http://worker-vnc:8081","supports_vnc":true,"vnc_ws":"ws://runner-vnc:6900","vnc_http":"http://runner-vnc:6900/vnc.html"}]
+#               Поддерживает плейсхолдеры {host} и {port}.
+CONTROL_WORKERS=[{"name":"worker-headless","url":"http://worker-headless:8080","supports_vnc":false},{"name":"worker-vnc","url":"http://worker-vnc:8081","supports_vnc":true,"vnc_ws":"ws://runner-vnc:{port}","vnc_http":"http://runner-vnc:{port}/vnc.html"}]

--- a/README.md
+++ b/README.md
@@ -215,6 +215,12 @@ cp .env.example .env
 - `vnc_ws` — базовый WebSocket URL предпросмотра (обязателен, если `supports_vnc=true`).
 - `vnc_http` — HTTP URL к noVNC iframe (опционально, если требуется веб-доступ).
 
+Значения `vnc_ws` и `vnc_http` поддерживают плейсхолдеры `{port}` и `{host}`. Плейсхолдеры могут
+использоваться в хосте, пути или query-строке: control-plane подставит фактический адрес и порт
+сессии, сохраняя остальные части URL. Это позволяет настраивать, например, публичные прокси
+через единый домен (`https://public.example/proxy/{port}`) или динамические поддомены
+(`wss://vnc-{port}.example`).
+
 ## Переменные окружения
 
 ### Runner
@@ -222,8 +228,8 @@ cp .env.example .env
 | Переменная | Значение по умолчанию | Описание |
 | ---------- | --------------------- | -------- |
 | `RUNNER_CORS_ORIGINS` | `['*']` | Список origin'ов (JSON-массив или через запятую) для CORS. Используйте конкретные домены в production; значение `*` автоматически отключает `allow_credentials`. |
-| `RUNNER_VNC_WS_BASE` | `None` | Базовый адрес (со схемой и хостом) для генерации WebSocket URL предпросмотра. Порт будет подменён на выделенный для конкретной сессии. |
-| `RUNNER_VNC_HTTP_BASE` | `None` | Аналогично `RUNNER_VNC_WS_BASE`, но для noVNC iframe (`/vnc.html`). |
+| `RUNNER_VNC_WS_BASE` | `None` | Базовый адрес (со схемой и хостом) для генерации WebSocket URL предпросмотра. Порт будет подменён на выделенный для конкретной сессии, поэтому задавайте значение без явного `:порт`. |
+| `RUNNER_VNC_HTTP_BASE` | `None` | Аналогично `RUNNER_VNC_WS_BASE`, но для noVNC iframe (`/vnc.html`): указывайте схему и хост без порта, runner добавит его автоматически. |
 | `RUNNER_VNC_DISPLAY_MIN` / `RUNNER_VNC_DISPLAY_MAX` | `100` / `199` | Диапазон виртуальных `DISPLAY`, выделяемых Xvfb. |
 | `RUNNER_VNC_PORT_MIN` / `RUNNER_VNC_PORT_MAX` | `5900` / `5999` | Диапазон TCP-портов для `x11vnc`. |
 | `RUNNER_VNC_WS_PORT_MIN` / `RUNNER_VNC_WS_PORT_MAX` | `6900` / `6999` | Диапазон TCP-портов для websockify/noVNC. |
@@ -252,7 +258,7 @@ cp .env.example .env
 | Переменная         | Значение по умолчанию | Описание                                         |
 | ------------------ | --------------------- | ------------------------------------------------ |
 | `CONTROL_CORS_ORIGINS` | `['*']`              | Origin'ы, которым разрешён доступ к API. При `*` `allow_credentials` отключается; для production перечислите конкретные домены. |
-| `CONTROL_WORKERS`  | см. config            | JSON-массив с воркерами: `name`, `url`, `supports_vnc`, `vnc_ws`, `vnc_http`. |
+| `CONTROL_WORKERS`  | см. config            | JSON-массив с воркерами (`name`, `url`, `supports_vnc`, `vnc_ws`, `vnc_http`). Поля `vnc_ws` и `vnc_http` поддерживают плейсхолдеры `{port}` и `{host}` для подстановки адреса активной сессии. |
 | `CONTROL_PORT`     | `9000`                | Порт HTTP API.                                   |
 | `CONTROL_METRICS_ENDPOINT` | `/metrics`     | Путь, на котором публикуются Prometheus-метрики. |
 

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -46,6 +46,7 @@ VNC-сессия. Для внешнего доступа настройте TCP-
 - `WORKER_RUNNER_BASE_URL` — адрес sidecar runner'а (по умолчанию `http://localhost:8070`).
 - `WORKER_SUPPORTS_VNC` — флаг, который сигнализирует control-plane, что воркер умеет в VNC.
 - `RUNNER_VNC_WS_BASE` / `RUNNER_VNC_HTTP_BASE` — задаются только для runner-vnc и используются UI.
+  Значения указываются без порта: runner автоматически добавит выделенный порт сессии.
 
 ### Control-plane
 
@@ -68,12 +69,14 @@ Example value:
     "name": "worker-vnc",
     "url": "http://camofleet-worker-vnc:8080",
     "supports_vnc": true,
-    "vnc_ws": "ws://camofleet-worker-vnc:6900",
-    "vnc_http": "http://camofleet-worker-vnc:6900"
+    "vnc_ws": "ws://camofleet-worker-vnc:{port}",
+    "vnc_http": "http://camofleet-worker-vnc:{port}"
   }
 ]
 ```
-Runner автоматически подменяет порт в этих базовых URL на выделенный для конкретной VNC-сессии.
+Control-plane подставляет порт и хост активной сессии в плейсхолдер `{port}` (и `{host}`, если он
+используется). Runner, в свою очередь, формирует исходные URL с фактическим портом из своего
+диапазона, поэтому UI и API получают корректные публичные адреса без ручных правок.
 
 ### UI
 

--- a/deploy/k8s/control.deployment.yaml
+++ b/deploy/k8s/control.deployment.yaml
@@ -9,7 +9,7 @@ data:
     [
       {"name":"worker-headless","url":"http://camofleet-worker:8080","supports_vnc":false},
       {"name":"worker-vnc","url":"http://camofleet-worker-vnc:8080","supports_vnc":true,
-       "vnc_ws":"ws://camofleet-worker-vnc:6900","vnc_http":"http://camofleet-worker-vnc:6900"}
+       "vnc_ws":"ws://camofleet-worker-vnc:{port}","vnc_http":"http://camofleet-worker-vnc:{port}"}
     ]
   CONTROL_PUBLIC_API_PREFIX: /api
 ---

--- a/deploy/k8s/worker-vnc.deployment.yaml
+++ b/deploy/k8s/worker-vnc.deployment.yaml
@@ -21,9 +21,9 @@ spec:
             - name: RUNNER_PORT
               value: "8070"
             - name: RUNNER_VNC_WS_BASE
-              value: ws://camofleet-worker-vnc:6900
+              value: ws://camofleet-worker-vnc
             - name: RUNNER_VNC_HTTP_BASE
-              value: http://camofleet-worker-vnc:6900
+              value: http://camofleet-worker-vnc
             - name: RUNNER_VNC_PORT_MIN
               value: "5900"
             - name: RUNNER_VNC_PORT_MAX

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,8 +16,8 @@ services:
       dockerfile: docker/Dockerfile.runner-vnc
     environment:
       RUNNER_PORT: 8070
-      RUNNER_VNC_WS_BASE: ws://localhost:6900
-      RUNNER_VNC_HTTP_BASE: http://localhost:6900
+      RUNNER_VNC_WS_BASE: ws://localhost
+      RUNNER_VNC_HTTP_BASE: http://localhost
     ports:
       - '6900-6999:6900-6999'
       - '5900-5999:5900-5999'
@@ -68,7 +68,7 @@ services:
         [
           {"name":"headless","url":"http://worker:8080","supports_vnc":false},
           {"name":"vnc","url":"http://worker-vnc:8080","supports_vnc":true,
-           "vnc_ws":"ws://localhost:6900","vnc_http":"http://localhost:6900"}
+           "vnc_ws":"ws://localhost:{port}","vnc_http":"http://localhost:{port}"}
         ]
     depends_on:
       - worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
       dockerfile: docker/Dockerfile.runner-vnc
     environment:
       RUNNER_PORT: 8070
-      RUNNER_VNC_WS_BASE: ws://localhost:6900
-      RUNNER_VNC_HTTP_BASE: http://localhost:6900
+      RUNNER_VNC_WS_BASE: ws://localhost
+      RUNNER_VNC_HTTP_BASE: http://localhost
     ports:
       - '6900-6999:6900-6999'
       - '5900-5999:5900-5999'
@@ -54,7 +54,7 @@ services:
         [
           {"name":"headless","url":"http://worker:8080","supports_vnc":false},
           {"name":"vnc","url":"http://worker-vnc:8080","supports_vnc":true,
-           "vnc_ws":"ws://localhost:6900","vnc_http":"http://localhost:6900"}
+           "vnc_ws":"ws://localhost:{port}","vnc_http":"http://localhost:{port}"}
         ]
     depends_on:
       - worker


### PR DESCRIPTION
## Summary
- allow control-plane VNC overrides to substitute dynamic host/port values and cover the new behavior with unit tests
- remove static VNC ports from docker-compose and Kubernetes manifests while documenting the {port}/{host} placeholders for operators
- refresh environment examples and READMEs to describe the new placeholder workflow and runner base URL expectations

## Testing
- PYTHONPATH=.. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d143272388832ab930dd4bc1320834