### PR TITLE
Refine worker status indicator mapping

### DIFF
--- a/ui/src/components/WorkerList.tsx
+++ b/ui/src/components/WorkerList.tsx
@@ -4,6 +4,111 @@ interface WorkerListProps {
   workers: WorkerStatus[];
 }
 
+type WorkerHealthIndicator = {
+  label: string;
+  className: string;
+};
+
+type WorkerHealthState = 'healthy' | 'degraded' | 'offline' | 'unknown';
+
+const HEALTHY_STATUSES = new Set(['ok', 'healthy', 'ready']);
+const DEGRADED_STATUSES = new Set([
+  'degraded',
+  'warning',
+  'starting',
+  'initialising',
+  'initializing',
+  'maintenance',
+  'pending',
+]);
+const OFFLINE_STATUSES = new Set([
+  'offline',
+  'unreachable',
+  'error',
+  'failed',
+  'down',
+  'timeout',
+  'stopped',
+]);
+
+function createIndicator(state: WorkerHealthState, label: string): WorkerHealthIndicator {
+  return {
+    label,
+    className: `worker-status-dot worker-status-dot--${state}`,
+  };
+}
+
+const DEFAULT_HEALTH = createIndicator('unknown', 'Unknown');
+
+function normaliseStatus(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed.toLowerCase() : null;
+}
+
+function formatStatusLabel(status: string): string {
+  return status
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function firstNonOkCheck(detail: WorkerStatus['detail'] | undefined): string | null {
+  const rawChecks = detail?.checks;
+  if (!rawChecks || typeof rawChecks !== 'object' || Array.isArray(rawChecks)) {
+    return null;
+  }
+
+  for (const value of Object.values(rawChecks as Record<string, unknown>)) {
+    const status = normaliseStatus(value);
+    if (status && !HEALTHY_STATUSES.has(status) && status !== 'unknown') {
+      return status;
+    }
+  }
+
+  return null;
+}
+
+function indicatorFromStatus(status: string): WorkerHealthIndicator {
+  if (HEALTHY_STATUSES.has(status)) {
+    return createIndicator('healthy', 'Healthy');
+  }
+  if (OFFLINE_STATUSES.has(status)) {
+    return createIndicator('offline', formatStatusLabel(status));
+  }
+  if (DEGRADED_STATUSES.has(status)) {
+    const label = status === 'starting' ? 'Starting' : formatStatusLabel(status);
+    return createIndicator('degraded', label);
+  }
+  if (status === 'unknown') {
+    return DEFAULT_HEALTH;
+  }
+  return createIndicator('unknown', formatStatusLabel(status));
+}
+
+function getWorkerHealth(worker: WorkerStatus): WorkerHealthIndicator {
+  if (!worker.healthy) {
+    return createIndicator('offline', 'Unreachable');
+  }
+
+  const statusText = normaliseStatus(worker.detail?.status);
+  const checkStatus = firstNonOkCheck(worker.detail);
+
+  if (checkStatus) {
+    const state = OFFLINE_STATUSES.has(checkStatus) ? 'offline' : 'degraded';
+    return createIndicator(state, formatStatusLabel(checkStatus));
+  }
+
+  if (statusText) {
+    return indicatorFromStatus(statusText);
+  }
+
+  return DEFAULT_HEALTH;
+}
+
 export function WorkerList({ workers }: WorkerListProps): JSX.Element {
   if (!workers.length) {
     return (
@@ -15,20 +120,20 @@ export function WorkerList({ workers }: WorkerListProps): JSX.Element {
 
   return (
     <ul className="worker-list">
-      {workers.map((worker) => (
-        <li key={worker.name}>
-          <span className={worker.healthy ? 'pill pill-healthy' : 'pill pill-offline'}>
-            {worker.healthy ? '●' : '○'}
-          </span>
-          <div>
-            <strong>{worker.name}</strong>
-            <small>
-              {worker.healthy ? 'Healthy' : 'Unreachable'} ·
-              {worker.supports_vnc ? ' VNC' : ' No VNC'}
-            </small>
-          </div>
-        </li>
-      ))}
+      {workers.map((worker) => {
+        const { label, className } = getWorkerHealth(worker);
+        return (
+          <li key={worker.name}>
+            <span className={className} aria-hidden="true" />
+            <div>
+              <strong>{worker.name}</strong>
+              <small>
+                {label} · {worker.supports_vnc ? 'VNC' : 'No VNC'}
+              </small>
+            </div>
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -151,22 +151,34 @@ input {
   color: var(--text-secondary-dark);
 }
 
-.worker-list .pill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
+.worker-status-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
-  font-size: 0.75rem;
+  flex-shrink: 0;
+  box-shadow: 0 0 0 3px rgba(15, 23, 42, 0.08);
+  transition: background-color 0.2s ease;
 }
 
-.pill-healthy {
-  color: var(--success);
+:root[data-theme='dark'] .worker-status-dot {
+  box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.18);
 }
 
-.pill-offline {
-  color: var(--danger);
+.worker-status-dot--healthy {
+  background: var(--success);
+}
+
+.worker-status-dot--degraded {
+  background: var(--warning);
+}
+
+.worker-status-dot--offline {
+  background: var(--danger);
+}
+
+.worker-status-dot--unknown {
+  background: var(--muted);
 }
 
 .sidebar .empty {


### PR DESCRIPTION
## Summary
- normalize worker status values and health check details to derive consistent indicator states
- reuse shared indicator builder to drive colored dots for healthy, degraded, offline and unknown cases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d152da8f74832aacdb3972b04abfa0