### PR TITLE
Handle cancellation in prewarm loop

### DIFF
--- a/runner/camoufox_runner/prewarm.py
+++ b/runner/camoufox_runner/prewarm.py
@@ -144,6 +144,8 @@ class PrewarmPool:
         while True:
             try:
                 await self.top_up_once()
+            except asyncio.CancelledError:
+                raise
             except Exception as exc:  # pragma: no cover - defensive
                 self._logger.warning("Prewarm loop error: %s", exc)
             await asyncio.sleep(self._check_interval)


### PR DESCRIPTION
## Summary
- ensure the prewarm loop re-raises asyncio.CancelledError so cancellation stops the task
- add a regression test that cancels a blocked launch and verifies stop/close clean up resources

## Testing
- pytest runner/tests/test_session_components.py

------
https://chatgpt.com/codex/tasks/task_e_68d17662d1c8832a95b81d8b82d1e459