### PR TITLE
Ensure VNC pool reuses released slots first

### DIFF
--- a/runner/camoufox_runner/vnc.py
+++ b/runner/camoufox_runner/vnc.py
@@ -75,9 +75,9 @@ class VncResourcePool:
             if slot not in self._active:
                 return
             self._active.remove(slot)
-            self._display_pool.append(slot.display)
-            self._vnc_ports.append(slot.vnc_port)
-            self._ws_ports.append(slot.ws_port)
+            self._display_pool.appendleft(slot.display)
+            self._vnc_ports.appendleft(slot.vnc_port)
+            self._ws_ports.appendleft(slot.ws_port)
 
 
 class VncProcessManager:

--- a/runner/tests/test_vnc_resource_pool.py
+++ b/runner/tests/test_vnc_resource_pool.py
@@ -1,0 +1,21 @@
+import pytest
+
+from runner.camoufox_runner.vnc import VncResourcePool
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_release_makes_slot_available_first():
+    pool = VncResourcePool(displays=[1], vnc_ports=[5900], ws_ports=[6000])
+
+    slot = await pool.acquire()
+
+    await pool.release(slot)
+
+    next_slot = await pool.acquire()
+
+    assert next_slot == slot


### PR DESCRIPTION
## Summary
- ensure released VNC slots are offered to the next acquire call by pushing them to the front of each queue
- add a regression test covering acquire-release-acquire reuse behaviour

## Testing
- pytest runner/tests

------
https://chatgpt.com/codex/tasks/task_e_68d181b994b8832abbca02dd5184a5be