### PR TITLE
Default Live Display embed to view mode

### DIFF
--- a/ui/src/components/SessionDetails.tsx
+++ b/ui/src/components/SessionDetails.tsx
@@ -21,6 +21,7 @@ function buildVncEmbedUrl(raw?: string | null): string | null {
     url.searchParams.set('autoconnect', '1');
     url.searchParams.set('resize', 'scale');
     url.searchParams.set('reconnect', 'true');
+    url.searchParams.set('view_only', 'true');
     return url.toString();
   } catch (error) {
     console.warn('Failed to build VNC URL', error);


### PR DESCRIPTION
## Summary
- set the embedded noVNC Live Display iframe to request view-only mode by default so users cannot take control inadvertently

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d183cd4eec832a8e62ab7410dbdf47