### PR TITLE
fix(ui): tighten wallboard controls overlay

### DIFF
--- a/ui/src/components/SessionDetails.tsx
+++ b/ui/src/components/SessionDetails.tsx
@@ -1,6 +1,7 @@
 import type { SessionItem } from '../api';
 import { formatStartUrlWait, getStatusBadgeClass } from '../utils/session';
 import { formatIdle, formatRelative, remainingIdleSeconds } from '../utils/time';
+import { buildVncEmbedUrl, buildVncViewerUrl } from '../utils/vnc';
 import { SessionControls } from './SessionControls';
 
 interface SessionDetailsProps {
@@ -12,21 +13,6 @@ interface SessionDetailsProps {
   onCopyWs: (endpoint: string) => void;
   isTouching: boolean;
   isKilling: boolean;
-}
-
-function buildVncEmbedUrl(raw?: string | null): string | null {
-  if (!raw) return null;
-  try {
-    const url = new URL(raw);
-    url.searchParams.set('autoconnect', '1');
-    url.searchParams.set('resize', 'scale');
-    url.searchParams.set('reconnect', 'true');
-    url.searchParams.set('view_only', 'true');
-    return url.toString();
-  } catch (error) {
-    console.warn('Failed to build VNC URL', error);
-    return raw;
-  }
 }
 
 export function SessionDetails({
@@ -117,7 +103,12 @@ export function SessionDetails({
           <h4>Live browser</h4>
           <div className="actions">
             {session.vnc?.http ? (
-              <a className="btn btn-secondary" href={session.vnc.http} target="_blank" rel="noreferrer">
+              <a
+                className="btn btn-secondary"
+                href={buildVncViewerUrl(session.vnc.http) ?? session.vnc.http}
+                target="_blank"
+                rel="noreferrer"
+              >
                 Open full screen
               </a>
             ) : null}

--- a/ui/src/components/SessionWallboard.tsx
+++ b/ui/src/components/SessionWallboard.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { SessionItem } from '../api';
+import { sessionKey } from '../utils/session';
+import { formatRelative } from '../utils/time';
+import { buildVncEmbedUrl, buildVncViewerUrl } from '../utils/vnc';
+
+const GRID_OPTIONS = [1, 4, 9] as const;
+
+type GridSize = (typeof GRID_OPTIONS)[number];
+
+interface SessionWallboardProps {
+  sessions: SessionItem[];
+  now: number;
+  onInspect: (session: SessionItem) => void;
+}
+
+interface FrameState {
+  [key: string]: number | undefined;
+}
+
+function columnsFor(size: GridSize): number {
+  if (size === 1) return 1;
+  if (size === 4) return 2;
+  if (size === 9) return 3;
+  return Math.ceil(Math.sqrt(size));
+}
+
+const FAILURE_GRACE_MS = Number(import.meta.env.VITE_WALLBOARD_FAILURE_GRACE_MS ?? 3000);
+const RETRY_DELAY_MS = Number(import.meta.env.VITE_WALLBOARD_RETRY_DELAY_MS ?? 10000);
+
+export function SessionWallboard({ sessions, now, onInspect }: SessionWallboardProps): JSX.Element {
+  const [gridSize, setGridSize] = useState<GridSize>(4);
+  const [page, setPage] = useState(0);
+  const [failedAt, setFailedAt] = useState<FrameState>({});
+
+  const sessionsWithVnc = useMemo(
+    () => sessions.filter((item) => Boolean(item.vnc?.http)),
+    [sessions],
+  );
+
+  useEffect(() => {
+    const allowedKeys = new Set(sessionsWithVnc.map((session) => sessionKey(session)));
+    setFailedAt((prev) => {
+      const next: FrameState = {};
+      let changed = false;
+      for (const [key, ts] of Object.entries(prev)) {
+        if (allowedKeys.has(key)) {
+          next[key] = ts;
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [sessionsWithVnc]);
+
+  useEffect(() => {
+    if (RETRY_DELAY_MS <= 0) return;
+    const interval = window.setInterval(() => {
+      const limit = Date.now() - (FAILURE_GRACE_MS + RETRY_DELAY_MS);
+      setFailedAt((prev) => {
+        const next: FrameState = {};
+        let changed = false;
+        for (const [key, ts] of Object.entries(prev)) {
+          if (typeof ts === 'number' && ts > limit) {
+            next[key] = ts;
+          } else if (typeof ts === 'number') {
+            changed = true;
+          }
+        }
+        return changed ? next : prev;
+      });
+    }, Math.max(2000, Math.min(10000, RETRY_DELAY_MS)));
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const { recoveringKeys, blockedKeys } = useMemo(() => {
+    const recovering = new Set<string>();
+    const blocked = new Set<string>();
+    for (const session of sessionsWithVnc) {
+      const key = sessionKey(session);
+      const failure = failedAt[key];
+      if (typeof failure !== 'number') continue;
+      const delta = now - failure;
+      if (delta < FAILURE_GRACE_MS) {
+        recovering.add(key);
+      } else {
+        blocked.add(key);
+      }
+    }
+    return { recoveringKeys: recovering, blockedKeys: blocked };
+  }, [sessionsWithVnc, failedAt, now]);
+
+  const availableSessions = useMemo(
+    () => sessionsWithVnc.filter((session) => !blockedKeys.has(sessionKey(session))),
+    [sessionsWithVnc, blockedKeys],
+  );
+
+  useEffect(() => {
+    setPage(0);
+  }, [gridSize]);
+
+  const maxPage = Math.max(0, Math.ceil(availableSessions.length / gridSize) - 1);
+
+  useEffect(() => {
+    setPage((prev) => (prev > maxPage ? maxPage : prev));
+  }, [maxPage]);
+
+  const startIndex = page * gridSize;
+  const visibleSessions = availableSessions.slice(startIndex, startIndex + gridSize);
+  const placeholders = Math.max(0, gridSize - visibleSessions.length);
+  const totalEligible = sessionsWithVnc.length;
+  const blockedCount = blockedKeys.size;
+  const columns = columnsFor(gridSize);
+
+  const handleFrameError = (key: string) => {
+    setFailedAt((prev) => {
+      if (typeof prev[key] === 'number') {
+        return prev;
+      }
+      return { ...prev, [key]: Date.now() };
+    });
+  };
+
+  const handleFrameLoad = (key: string) => {
+    setFailedAt((prev) => {
+      if (typeof prev[key] !== 'number') {
+        return prev;
+      }
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  };
+
+  const hasPrev = page > 0;
+  const hasNext = page < maxPage;
+  const totalPages = maxPage + 1;
+
+  return (
+    <section className="panel wallboard-panel">
+      <header className="panel-header wallboard-header">
+        <div>
+          <h2>Live wallboard</h2>
+          <p>
+            Showing {visibleSessions.length} of {availableSessions.length} VNC sessions
+            {blockedCount ? ` · ${blockedCount} waiting to reconnect` : ''}
+          </p>
+        </div>
+        <div className="wallboard-toolbar">
+          <div className="layout-switcher" role="group" aria-label="Grid size">
+            {GRID_OPTIONS.map((option) => (
+              <button
+                key={option}
+                type="button"
+                className={`tab-button${gridSize === option ? ' tab-button--active' : ''}`}
+                onClick={() => setGridSize(option)}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+          <div className="pager">
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => setPage((prev) => Math.max(0, prev - 1))}
+              disabled={!hasPrev}
+            >
+              ◀
+            </button>
+            <span className="pager-info">
+              {totalPages > 0 ? `${page + 1} / ${totalPages}` : '0 / 0'}
+            </span>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => setPage((prev) => Math.min(maxPage, prev + 1))}
+              disabled={!hasNext}
+            >
+              ▶
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div className="wallboard-grid" style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}>
+        {visibleSessions.map((session) => {
+          const key = sessionKey(session);
+          const failure = failedAt[key];
+          const isRecovering = recoveringKeys.has(key);
+          const remainingMs = typeof failure === 'number' ? Math.max(0, FAILURE_GRACE_MS - (now - failure)) : 0;
+          return (
+            <article key={key} className={`wallboard-tile${isRecovering ? ' wallboard-tile--recovering' : ''}`}>
+              <div className="wallboard-tile__actions" role="group" aria-label="Session shortcuts">
+                {session.vnc?.http ? (
+                  <a
+                    className="wallboard-tile__action"
+                    href={buildVncViewerUrl(session.vnc?.http) ?? session.vnc?.http ?? undefined}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    Open VNC
+                  </a>
+                ) : null}
+                <button
+                  type="button"
+                  className="wallboard-tile__action"
+                  onClick={() => onInspect(session)}
+                >
+                  Inspect
+                </button>
+              </div>
+              <header className="wallboard-tile__header">
+                <div className="wallboard-tile__meta">
+                  <span className="wallboard-tile__worker">{session.worker}</span>
+                  <span className="wallboard-tile__id">{session.id}</span>
+                </div>
+              </header>
+              <iframe
+                title={`Session ${session.id}`}
+                src={buildVncEmbedUrl(session.vnc?.http) ?? undefined}
+                className="wallboard-frame"
+                onLoad={() => handleFrameLoad(key)}
+                onError={() => handleFrameError(key)}
+              />
+              <footer className="wallboard-tile__footer">
+                <span className="status">{session.status}</span>
+                <span className="timestamp">Last activity · {formatRelative(session.last_seen_at)}</span>
+              </footer>
+              {isRecovering ? (
+                <div className="wallboard-tile__overlay">
+                  <span>Reconnecting… {Math.ceil(remainingMs / 1000)}s</span>
+                </div>
+              ) : null}
+            </article>
+          );
+        })}
+        {Array.from({ length: placeholders }).map((_, index) => (
+          <div key={`placeholder-${index}`} className="wallboard-tile wallboard-tile--placeholder">
+            <span>No session</span>
+          </div>
+        ))}
+      </div>
+
+      {totalEligible === 0 ? (
+        <div className="wallboard-empty">
+          <p>No VNC-enabled sessions are available yet.</p>
+        </div>
+      ) : null}
+      {totalEligible > 0 && availableSessions.length === 0 ? (
+        <div className="wallboard-empty">
+          <p>All available sessions are temporarily offline. Waiting for reconnect…</p>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -27,6 +27,7 @@
   --muted-dark: #64748b;
   --card-shadow: 0 18px 50px rgba(15, 23, 42, 0.08);
   --card-shadow-dark: 0 18px 50px rgba(15, 23, 42, 0.35);
+  --topbar-control-height: 48px;
   background-color: var(--bg-app);
   color: var(--text-primary);
 }
@@ -346,15 +347,81 @@ input {
   display: flex;
   flex-wrap: wrap;
   gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.topbar-stats {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 12px;
+}
+
+.main-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px;
+  border-radius: 999px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--card-shadow);
+  min-height: var(--topbar-control-height);
+  height: var(--topbar-control-height);
+  flex-shrink: 0;
+}
+
+:root[data-theme='dark'] .main-tabs {
+  background: var(--bg-panel-dark);
+  border-color: var(--border-color-dark);
+  box-shadow: var(--card-shadow-dark);
+}
+
+.tab-button {
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  padding: 8px 20px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+
+.tab-button:hover {
+  transform: translateY(-1px);
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent);
+}
+
+.tab-button--active {
+  background: var(--accent);
+  color: white;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+}
+
+:root[data-theme='dark'] .tab-button--active {
+  background: var(--accent-dark);
+  box-shadow: 0 12px 24px rgba(14, 165, 233, 0.25);
+  color: #0f172a;
 }
 
 .stat {
   background: var(--bg-panel);
   border-radius: 16px;
-  padding: 16px 20px;
+  padding: 8px 18px;
   min-width: 120px;
+  min-height: var(--topbar-control-height);
+  height: var(--topbar-control-height);
   border: 1px solid var(--border-color);
   box-shadow: var(--card-shadow);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
 }
 
 :root[data-theme='dark'] .stat {
@@ -368,6 +435,7 @@ input {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  line-height: 1;
   color: var(--text-secondary);
 }
 
@@ -377,8 +445,9 @@ input {
 
 .stat-value {
   display: block;
-  font-size: 1.5rem;
+  font-size: 1.35rem;
   font-weight: 600;
+  line-height: 1.1;
 }
 
 .content-grid {
@@ -590,6 +659,243 @@ input {
 :root[data-theme='dark'] .vnc-frame {
   border-color: var(--border-color-dark);
   background: #0f172a;
+}
+
+.wallboard-panel {
+  gap: 20px;
+}
+
+.wallboard-header {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.wallboard-toolbar {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.layout-switcher {
+  display: inline-flex;
+  gap: 6px;
+  padding: 4px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.08);
+}
+
+:root[data-theme='dark'] .layout-switcher {
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.layout-switcher .tab-button {
+  padding: 6px 14px;
+  font-size: 0.9rem;
+}
+
+.layout-switcher .tab-button:hover {
+  background: rgba(37, 99, 235, 0.18);
+}
+
+.layout-switcher .tab-button--active {
+  background: var(--accent);
+  color: white;
+  box-shadow: none;
+}
+
+:root[data-theme='dark'] .layout-switcher .tab-button--active {
+  background: var(--accent-dark);
+  color: #0f172a;
+}
+
+.pager {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pager .btn {
+  min-width: 44px;
+  justify-content: center;
+}
+
+.pager-info {
+  font-weight: 600;
+  min-width: 68px;
+  text-align: center;
+}
+
+.wallboard-grid {
+  display: grid;
+  gap: 16px;
+  width: 100%;
+}
+
+.wallboard-tile {
+  position: relative;
+  border-radius: 16px;
+  overflow: hidden;
+  aspect-ratio: 16 / 10;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--card-shadow);
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+:root[data-theme='dark'] .wallboard-tile {
+  border-color: var(--border-color-dark);
+  box-shadow: var(--card-shadow-dark);
+  background: #020617;
+  color: #f8fafc;
+}
+
+.wallboard-frame {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: #000;
+}
+
+.wallboard-tile__header,
+.wallboard-tile__footer {
+  position: absolute;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 12px;
+  font-size: 0.75rem;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.wallboard-tile__header {
+  top: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0));
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+.wallboard-tile__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.wallboard-tile__actions {
+  position: absolute;
+  top: 8px;
+  left: 12px;
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  pointer-events: auto;
+  z-index: 3;
+}
+
+.wallboard-tile__action {
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.85);
+  background: rgba(15, 23, 42, 0.92);
+  color: #f8fafc;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color 0.15s ease, transform 0.15s ease, border-color 0.15s ease;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 4px 12px;
+  line-height: 1.1;
+  min-height: 28px;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.35);
+}
+
+.wallboard-tile__action:hover {
+  background: rgba(37, 99, 235, 0.92);
+  border-color: rgba(37, 99, 235, 0.95);
+  transform: translateY(-1px);
+}
+
+.wallboard-tile__action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.wallboard-tile__footer {
+  bottom: 0;
+  background: linear-gradient(0deg, rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0));
+  flex-direction: column;
+  gap: 4px;
+}
+
+.wallboard-tile__worker {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.wallboard-tile__id {
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Consolas, monospace;
+}
+
+.wallboard-tile__footer .status {
+  font-weight: 600;
+}
+
+.wallboard-tile__footer .timestamp {
+  font-size: 0.7rem;
+  opacity: 0.75;
+}
+
+.wallboard-tile__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.82);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  z-index: 3;
+}
+
+.wallboard-tile--placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.6);
+  background: #000;
+  border-style: dashed;
+  box-shadow: none;
+}
+
+:root[data-theme='dark'] .wallboard-tile--placeholder {
+  border-color: rgba(148, 163, 184, 0.3);
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.wallboard-empty {
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+:root[data-theme='dark'] .wallboard-empty {
+  color: var(--text-secondary-dark);
 }
 
 .empty,

--- a/ui/src/utils/vnc.ts
+++ b/ui/src/utils/vnc.ts
@@ -1,0 +1,27 @@
+function buildVncUrl(raw?: string | null): URL | null {
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    url.searchParams.set('autoconnect', '1');
+    url.searchParams.set('reconnect', 'true');
+    return url;
+  } catch (error) {
+    console.warn('Failed to build VNC URL', error);
+    return null;
+  }
+}
+
+export function buildVncEmbedUrl(raw?: string | null): string | null {
+  const url = buildVncUrl(raw);
+  if (!url) return raw ?? null;
+  url.searchParams.set('resize', 'scale');
+  url.searchParams.set('view_only', 'true');
+  return url.toString();
+}
+
+export function buildVncViewerUrl(raw?: string | null): string | null {
+  const url = buildVncUrl(raw);
+  if (!url) return raw ?? null;
+  url.searchParams.set('view_only', 'true');
+  return url.toString();
+}


### PR DESCRIPTION
## Summary
- reposition and restyle the wallboard shortcut buttons so they sit over the built-in VNC label with a smaller, more opaque pill treatment
- ensure wallboard and session detail VNC links launch the viewer in view-only mode by default while keeping the embedded frames unaffected

## Testing
- npm run build
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d18aa20f88832a89fe5b164ac9b7ff