### PR TITLE
Add Traefik TCP ingress for runner VNC port 6901

### DIFF
--- a/deploy/traefik/camofleet-runner-vnc-6901-irtcp.yaml
+++ b/deploy/traefik/camofleet-runner-vnc-6901-irtcp.yaml
@@ -1,0 +1,13 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: camofleet-runner-vnc-6901
+  namespace: camofleet
+spec:
+  entryPoints:
+    - vnc-ws-6901
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: camofleet-worker-vnc
+          port: 6901


### PR DESCRIPTION
## Summary
- add a Traefik IngressRouteTCP manifest to expose runner VNC websocket port 6901 via a dedicated entrypoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d39580df8c832aac0b83a42cb03885