### PR TITLE
feat(helm): add traefik ingressroute support

### DIFF
--- a/deploy/helm/camo-fleet/templates/control-configmap.yaml
+++ b/deploy/helm/camo-fleet/templates/control-configmap.yaml
@@ -8,14 +8,49 @@
 {{- $workerVncConfig := dict "name" "worker-vnc" "url" (printf "http://%s:%d" $workerVncService (.Values.workerVnc.service.port | int)) "supports_vnc" true -}}
 {{- $vncOverrides := default dict .Values.workerVnc.controlOverrides -}}
 {{- $vncWsOverride := index $vncOverrides "ws" -}}
+{{- $rawVncHost := default .Values.ingress.host .Values.workerVnc.ingressRoute.host -}}
+{{- $vncHostValue := trim (default "" $rawVncHost) -}}
+{{- $ingressConfigured := and .Values.workerVnc.ingressRoute.enabled $vncHostValue -}}
 {{- if $vncWsOverride -}}
 {{- $_ := set $workerVncConfig "vnc_ws" $vncWsOverride -}}
+{{- else if $ingressConfigured -}}
+{{- $vncHost := $vncHostValue -}}
+{{- $vncIngress := .Values.workerVnc.ingressRoute | default dict -}}
+{{- $vncPathPrefix := default "/vnc" $vncIngress.pathPrefix -}}
+{{- $vncPathBase := trimSuffix "/" $vncPathPrefix -}}
+{{- if eq $vncPathBase "" -}}
+{{- $vncPathBase = "/vnc" -}}
+{{- end -}}
+{{- $vncTls := $vncIngress.tls | default dict -}}
+{{- $tlsEnabled := or ($vncTls.enabled) ($vncTls.secretName) ($vncTls.certResolver) -}}
+{{- if not $tlsEnabled -}}
+{{- $globalTls := .Values.ingress.tls | default dict -}}
+{{- $tlsEnabled = or ($globalTls.enabled) ($globalTls.secretName) ($globalTls.certResolver) -}}
+{{- end -}}
+{{- $wsScheme := ternary "wss" "ws" $tlsEnabled -}}
+{{- $_ := set $workerVncConfig "vnc_ws" (printf "%s://%s%s/{port}/websockify" $wsScheme $vncHost $vncPathBase) -}}
 {{- else -}}
 {{- $_ := set $workerVncConfig "vnc_ws" (printf "ws://%s:{port}" $workerVncService) -}}
 {{- end -}}
 {{- $vncHttpOverride := index $vncOverrides "http" -}}
 {{- if $vncHttpOverride -}}
 {{- $_ := set $workerVncConfig "vnc_http" $vncHttpOverride -}}
+{{- else if $ingressConfigured -}}
+{{- $vncHost := $vncHostValue -}}
+{{- $vncIngress := .Values.workerVnc.ingressRoute | default dict -}}
+{{- $vncPathPrefix := default "/vnc" $vncIngress.pathPrefix -}}
+{{- $vncPathBase := trimSuffix "/" $vncPathPrefix -}}
+{{- if eq $vncPathBase "" -}}
+{{- $vncPathBase = "/vnc" -}}
+{{- end -}}
+{{- $vncTls := $vncIngress.tls | default dict -}}
+{{- $tlsEnabled := or ($vncTls.enabled) ($vncTls.secretName) ($vncTls.certResolver) -}}
+{{- if not $tlsEnabled -}}
+{{- $globalTls := .Values.ingress.tls | default dict -}}
+{{- $tlsEnabled = or ($globalTls.enabled) ($globalTls.secretName) ($globalTls.certResolver) -}}
+{{- end -}}
+{{- $httpScheme := ternary "https" "http" $tlsEnabled -}}
+{{- $_ := set $workerVncConfig "vnc_http" (printf "%s://%s%s/{port}/vnc.html" $httpScheme $vncHost $vncPathBase) -}}
 {{- else -}}
 {{- $_ := set $workerVncConfig "vnc_http" (printf "http://%s:{port}" $workerVncService) -}}
 {{- end -}}

--- a/deploy/helm/camo-fleet/templates/ingressroute.yaml
+++ b/deploy/helm/camo-fleet/templates/ingressroute.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.ingress.enabled }}
+{{- $host := required "ingress.host must be provided when ingress.enabled is true" .Values.ingress.host | trim }}
+{{- $className := .Values.ingress.className | trim }}
+{{- $entryPoints := default (list) .Values.ingress.entryPoints }}
+{{- $globalMiddlewares := default (list) .Values.ingress.middlewares }}
+{{- $routes := .Values.ingress.routes | default dict }}
+{{- $uiRoute := mergeOverwrite (dict "enabled" true "pathPrefix" "/" "middlewares" (list)) (index $routes "ui" | default dict) }}
+{{- $controlRoute := mergeOverwrite (dict "enabled" true "pathPrefix" "/api" "middlewares" (list)) (index $routes "control" | default dict) }}
+{{- $uiPath := default "/" $uiRoute.pathPrefix }}
+{{- if not (hasPrefix $uiPath "/") }}
+{{- fail (printf "ingress.routes.ui.pathPrefix (%s) must start with '/'" $uiPath) }}
+{{- end }}
+{{- $controlPath := default "/api" $controlRoute.pathPrefix }}
+{{- if not (hasPrefix $controlPath "/") }}
+{{- fail (printf "ingress.routes.control.pathPrefix (%s) must start with '/'" $controlPath) }}
+{{- end }}
+{{- $uiMiddlewares := concat $globalMiddlewares (default (list) $uiRoute.middlewares) }}
+{{- $controlMiddlewares := concat $globalMiddlewares (default (list) $controlRoute.middlewares) }}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "camofleet.fullname" . }}
+  labels:
+    app: {{ include "camofleet.fullname" . }}
+{{ include "camofleet.labels" . | indent 4 }}
+{{- if $className }}
+  annotations:
+    kubernetes.io/ingress.class: {{ $className | quote }}
+{{- end }}
+spec:
+{{- if $entryPoints }}
+  entryPoints:
+{{ toYaml $entryPoints | indent 4 }}
+{{- end }}
+  routes:
+{{- if $uiRoute.enabled }}
+    - match: Host(`{{ $host }}`) && PathPrefix(`{{ $uiPath }}`)
+      kind: Rule
+{{- if $uiMiddlewares }}
+      middlewares:
+{{- range $uiMiddlewares }}
+        - name: {{ .name | quote }}
+{{- if .namespace }}
+          namespace: {{ .namespace | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+      services:
+        - name: {{ include "camofleet.ui.fullname" . }}
+          port: {{ .Values.ui.service.port | int }}
+{{- end }}
+{{- if $controlRoute.enabled }}
+    - match: Host(`{{ $host }}`) && PathPrefix(`{{ $controlPath }}`)
+      kind: Rule
+{{- if $controlMiddlewares }}
+      middlewares:
+{{- range $controlMiddlewares }}
+        - name: {{ .name | quote }}
+{{- if .namespace }}
+          namespace: {{ .namespace | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+      services:
+        - name: {{ include "camofleet.control.fullname" . }}
+          port: {{ .Values.control.service.port | int }}
+{{- end }}
+{{- $tls := .Values.ingress.tls | default dict }}
+{{- $tlsEnabled := or ($tls.enabled) ($tls.secretName) ($tls.certResolver) }}
+{{- if $tlsEnabled }}
+  tls:
+{{- if $tls.secretName }}
+    secretName: {{ $tls.secretName | quote }}
+{{- end }}
+{{- if $tls.certResolver }}
+    certResolver: {{ $tls.certResolver | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/camo-fleet/templates/worker-vnc-ingressroute.yaml
+++ b/deploy/helm/camo-fleet/templates/worker-vnc-ingressroute.yaml
@@ -1,0 +1,92 @@
+{{- if and .Values.workerVnc.enabled .Values.workerVnc.ingressRoute.enabled }}
+{{- $host := default .Values.ingress.host (.Values.workerVnc.ingressRoute.host | trim) | trim }}
+{{- if not $host }}
+{{- fail "workerVnc.ingressRoute.host must be provided when ingress route is enabled (or set ingress.host)" }}
+{{- end }}
+{{- $className := default .Values.ingress.className .Values.workerVnc.ingressRoute.className | trim }}
+{{- $entryPoints := default (list) .Values.workerVnc.ingressRoute.entryPoints }}
+{{- $pathPrefix := default "/vnc" .Values.workerVnc.ingressRoute.pathPrefix }}
+{{- if not (hasPrefix $pathPrefix "/") }}
+{{- fail (printf "workerVnc.ingressRoute.pathPrefix (%s) must start with '/'" $pathPrefix) }}
+{{- end }}
+{{- $pathBase := trimSuffix "/" $pathPrefix }}
+{{- if eq $pathBase "" }}
+{{- fail "workerVnc.ingressRoute.pathPrefix cannot be the root path" }}
+{{- end }}
+{{- $stripConfig := .Values.workerVnc.ingressRoute.stripPrefixRegex | default dict }}
+{{- $stripEnabled := $stripConfig.enabled | default false }}
+{{- $stripPattern := $stripConfig.pattern | default "" }}
+{{- if and $stripEnabled (eq $stripPattern "") }}
+{{- $escaped := regexReplaceAll "([\\.^$|?*+()\[\]{}])" $pathBase "\\$1" }}
+{{- $stripPattern = printf "^%s/[0-9]+" $escaped }}
+{{- end }}
+{{- $stripName := $stripConfig.name | default (printf "%s-strip" (include "camofleet.workerVnc.fullname" .)) }}
+{{- $customMiddlewares := default (list) .Values.workerVnc.ingressRoute.middlewares }}
+{{- $wsMin := int .Values.workerVnc.vncPortRange.ws.min }}
+{{- $wsMax := int .Values.workerVnc.vncPortRange.ws.max }}
+{{- if gt $wsMin $wsMax }}
+{{- fail (printf "workerVnc.vncPortRange.ws.min (%d) must be less than or equal to workerVnc.vncPortRange.ws.max (%d)" $wsMin $wsMax) }}
+{{- end }}
+{{- $serviceName := include "camofleet.workerVnc.fullname" . }}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ printf "%s-vnc" $serviceName }}
+  labels:
+    app: {{ $serviceName }}
+{{ include "camofleet.labels" . | indent 4 }}
+{{- if $className }}
+  annotations:
+    kubernetes.io/ingress.class: {{ $className | quote }}
+{{- end }}
+spec:
+{{- if $entryPoints }}
+  entryPoints:
+{{ toYaml $entryPoints | indent 4 }}
+{{- end }}
+  routes:
+{{- $upper := int (add $wsMax 1) }}
+{{- range $port := untilStep $wsMin $upper 1 }}
+    - match: Host(`{{ $host }}`) && PathPrefix(`{{ printf "%s/%d" $pathBase $port }}`)
+      kind: Rule
+{{- if $stripEnabled }}
+      middlewares:
+        - name: {{ $stripName | quote }}
+{{- if $customMiddlewares }}
+{{- range $customMiddlewares }}
+        - name: {{ .name | quote }}
+{{- if .namespace }}
+          namespace: {{ .namespace | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- else if $customMiddlewares }}
+      middlewares:
+{{- range $customMiddlewares }}
+        - name: {{ .name | quote }}
+{{- if .namespace }}
+          namespace: {{ .namespace | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+      services:
+{{- if .Values.workerVnc.traefikService.enabled }}
+        - kind: TraefikService
+          name: {{ printf "%s-%d" $serviceName $port }}
+{{- else }}
+        - name: {{ $serviceName }}
+          port: {{ $port }}
+{{- end }}
+{{- end }}
+{{- $tls := .Values.workerVnc.ingressRoute.tls | default dict }}
+{{- $tlsEnabled := or ($tls.enabled) ($tls.secretName) ($tls.certResolver) }}
+{{- if $tlsEnabled }}
+  tls:
+{{- if $tls.secretName }}
+    secretName: {{ $tls.secretName | quote }}
+{{- end }}
+{{- if $tls.certResolver }}
+    certResolver: {{ $tls.certResolver | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/camo-fleet/templates/worker-vnc-middleware.yaml
+++ b/deploy/helm/camo-fleet/templates/worker-vnc-middleware.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.workerVnc.enabled .Values.workerVnc.ingressRoute.enabled }}
+{{- $stripConfig := .Values.workerVnc.ingressRoute.stripPrefixRegex | default dict }}
+{{- $stripEnabled := $stripConfig.enabled | default false }}
+{{- if $stripEnabled }}
+{{- $pathPrefix := default "/vnc" .Values.workerVnc.ingressRoute.pathPrefix }}
+{{- if not (hasPrefix $pathPrefix "/") }}
+{{- fail (printf "workerVnc.ingressRoute.pathPrefix (%s) must start with '/'" $pathPrefix) }}
+{{- end }}
+{{- $pathBase := trimSuffix "/" $pathPrefix }}
+{{- if eq $pathBase "" }}
+{{- fail "workerVnc.ingressRoute.pathPrefix cannot be the root path" }}
+{{- end }}
+{{- $stripPattern := $stripConfig.pattern | default "" }}
+{{- if eq $stripPattern "" }}
+{{- $escaped := regexReplaceAll "([\\.^$|?*+()\[\]{}])" $pathBase "\\$1" }}
+{{- $stripPattern = printf "^%s/[0-9]+" $escaped }}
+{{- end }}
+{{- $stripName := $stripConfig.name | default (printf "%s-strip" (include "camofleet.workerVnc.fullname" .)) }}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $stripName }}
+  labels:
+    app: {{ include "camofleet.workerVnc.fullname" . }}
+{{ include "camofleet.labels" . | indent 4 }}
+spec:
+  stripPrefixRegex:
+    regex:
+      - {{ $stripPattern | quote }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/camo-fleet/values.yaml
+++ b/deploy/helm/camo-fleet/values.yaml
@@ -2,6 +2,29 @@ global:
   imageRegistry: ""
   imagePullSecrets: []
 
+ingress:
+  enabled: false
+  host: ""
+  className: ""
+  entryPoints:
+    - websecure
+  middlewares: []
+    # - name: traefik-auth
+    #   namespace: traefik
+  tls:
+    enabled: false
+    secretName: ""
+    certResolver: ""
+  routes:
+    ui:
+      enabled: true
+      pathPrefix: /
+      middlewares: []
+    control:
+      enabled: true
+      pathPrefix: /api
+      middlewares: []
+
 control:
   replicas: 1
   image:
@@ -89,8 +112,26 @@ workerVnc:
       max: 5904
   traefikService:
     enabled: false
+  ingressRoute:
+    enabled: false
+    host: ""
+    className: ""
+    entryPoints:
+      - websecure
+    pathPrefix: /vnc
+    middlewares: []
+      # - name: traefik-auth
+      #   namespace: traefik
+    stripPrefixRegex:
+      enabled: true
+      pattern: ""
+      name: ""
+    tls:
+      enabled: false
+      secretName: ""
+      certResolver: ""
   extraEnv: []
   sessionDefaults: {}
   controlOverrides:
-    ws: wss://camofleet.services.synestra.tech/vnc/{port}/websockify
-    http: https://camofleet.services.synestra.tech/vnc/{port}/vnc.html
+    ws: null
+    http: null


### PR DESCRIPTION
## Summary
- add Traefik IngressRoute templates for the UI/control services and optional VNC publishing
- extend chart values and control-plane config to derive public VNC URLs from ingress settings
- document the new Helm configuration and provide an end-to-end deployment script

## Testing
- not run (helm binary is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3bf755ac0832a9b0e8b034d40d7d5