### PR TITLE
Fix worker VNC middleware strip pattern template

### DIFF
--- a/deploy/helm/camo-fleet/templates/worker-vnc-middleware.yaml
+++ b/deploy/helm/camo-fleet/templates/worker-vnc-middleware.yaml
@@ -10,11 +10,8 @@
 {{- if eq $pathBase "" }}
 {{- fail "workerVnc.ingressRoute.pathPrefix cannot be the root path" }}
 {{- end }}
-{{- $stripPattern := $stripConfig.pattern | default "" }}
-{{- if eq $stripPattern "" }}
 {{- $escaped := regexReplaceAll "([\\.^$|?*+()\[\]{}])" $pathBase "\\$1" }}
-{{- $stripPattern = printf "^%s/[0-9]+" $escaped }}
-{{- end }}
+{{- $stripPattern := default (printf "^%s/[0-9]+" $escaped) $stripConfig.pattern }}
 {{- $stripName := $stripConfig.name | default (printf "%s-strip" (include "camofleet.workerVnc.fullname" .)) }}
 apiVersion: traefik.io/v1alpha1
 kind: Middleware


### PR DESCRIPTION
## Summary
- compute the worker VNC middleware stripPrefixRegex pattern using Helm's `default` helper so the template avoids invalid reassignment syntax

## Testing
- ⚠️ `helm template camofleet .` *(fails: `helm` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c9e46164832ab9f085709a947cf7