### PR TITLE
Use regexQuoteMeta for VNC strip pattern

### DIFF
--- a/deploy/helm/camo-fleet/templates/worker-vnc-middleware.yaml
+++ b/deploy/helm/camo-fleet/templates/worker-vnc-middleware.yaml
@@ -10,11 +10,8 @@
 {{- if eq $pathBase "" }}
 {{- fail "workerVnc.ingressRoute.pathPrefix cannot be the root path" }}
 {{- end }}
-{{- $stripPattern := $stripConfig.pattern | default "" }}
-{{- if eq $stripPattern "" }}
-{{- $escaped := regexReplaceAll "([\\.^$|?*+()\[\]{}])" $pathBase "\\$1" }}
-{{- $stripPattern = printf "^%s/[0-9]+" $escaped }}
-{{- end }}
+{{- $escaped := regexQuoteMeta $pathBase }}
+{{- $stripPattern := default (printf "^%s/[0-9]+" $escaped) $stripConfig.pattern }}
 {{- $stripName := $stripConfig.name | default (printf "%s-strip" (include "camofleet.workerVnc.fullname" .)) }}
 apiVersion: traefik.io/v1alpha1
 kind: Middleware


### PR DESCRIPTION
## Summary
- escape the worker VNC stripPrefixRegex default with Helm's regexQuoteMeta helper to avoid template syntax errors

## Testing
- ⚠️ `helm template camofleet .` *(not run: `helm` command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c9e46164832ab9f085709a947cf7