### PR TITLE
Trim worker VNC path prefix values

### DIFF
--- a/deploy/helm/camo-fleet/templates/worker-vnc-ingressroute.yaml
+++ b/deploy/helm/camo-fleet/templates/worker-vnc-ingressroute.yaml
@@ -9,6 +9,7 @@
 {{- $className := default .Values.ingress.className .Values.workerVnc.ingressRoute.className | trim }}
 {{- $entryPoints := default (list) .Values.workerVnc.ingressRoute.entryPoints }}
 {{- $pathPrefix := default "/vnc" .Values.workerVnc.ingressRoute.pathPrefix }}
+{{- $pathPrefix = trim $pathPrefix }}
 {{- if not (hasPrefix $pathPrefix "/") }}
 {{- fail (printf "workerVnc.ingressRoute.pathPrefix (%s) must start with '/'" $pathPrefix) }}
 {{- end }}

--- a/deploy/helm/camo-fleet/templates/worker-vnc-middleware.yaml
+++ b/deploy/helm/camo-fleet/templates/worker-vnc-middleware.yaml
@@ -6,6 +6,7 @@
 {{- $stripEnabled := $stripConfig.enabled | default false }}
 {{- if $stripEnabled }}
 {{- $pathPrefix := default "/vnc" .Values.workerVnc.ingressRoute.pathPrefix }}
+{{- $pathPrefix = trim $pathPrefix }}
 {{- if not (hasPrefix $pathPrefix "/") }}
 {{- fail (printf "workerVnc.ingressRoute.pathPrefix (%s) must start with '/'" $pathPrefix) }}
 {{- end }}


### PR DESCRIPTION
## Summary
- trim whitespace from the worker VNC ingress route path prefix before validating it
- ensure the middleware template uses the sanitized path prefix for validation

## Testing
- helm template camo-fleet .

------
https://chatgpt.com/codex/tasks/task_e_68d3efd1cb44832aa1c2c2e7c53636ba