### PR TITLE
Fix ingress route path prefix validation

### DIFF
--- a/deploy/helm/camo-fleet/templates/ingressroute.yaml
+++ b/deploy/helm/camo-fleet/templates/ingressroute.yaml
@@ -7,11 +7,11 @@
 {{- $uiRoute := mergeOverwrite (dict "enabled" true "pathPrefix" "/" "middlewares" (list)) (index $routes "ui" | default dict) }}
 {{- $controlRoute := mergeOverwrite (dict "enabled" true "pathPrefix" "/api" "middlewares" (list)) (index $routes "control" | default dict) }}
 {{- $uiPath := default "/" $uiRoute.pathPrefix }}
-{{- if not (hasPrefix $uiPath "/") }}
+{{- if not (hasPrefix "/" $uiPath) }}
 {{- fail (printf "ingress.routes.ui.pathPrefix (%s) must start with '/'" $uiPath) }}
 {{- end }}
 {{- $controlPath := default "/api" $controlRoute.pathPrefix }}
-{{- if not (hasPrefix $controlPath "/") }}
+{{- if not (hasPrefix "/" $controlPath) }}
 {{- fail (printf "ingress.routes.control.pathPrefix (%s) must start with '/'" $controlPath) }}
 {{- end }}
 {{- $uiMiddlewares := concat $globalMiddlewares (default (list) $uiRoute.middlewares) }}


### PR DESCRIPTION
## Summary
- correct the ingress route path prefix validation to pass hasPrefix the prefix argument first

## Testing
- helm lint deploy/helm/camo-fleet
- helm lint deploy/helm/camo-fleet --set ingress.enabled=true --set ingress.host=camofleet.example.com
- helm template camofleet deploy/helm/camo-fleet >/tmp/camofleet.yaml
- helm template camofleet deploy/helm/camo-fleet --set ingress.enabled=true --set ingress.host=camofleet.example.com >/tmp/camofleet-ingress.yaml

------
https://chatgpt.com/codex/tasks/task_e_68d3f131a1c0832a9956596910d20736