### PR TITLE
Fix Helm templates for worker VNC ingress route

### DIFF
--- a/deploy/helm/camo-fleet/templates/control-configmap.yaml
+++ b/deploy/helm/camo-fleet/templates/control-configmap.yaml
@@ -22,10 +22,10 @@
 {{- $vncPathBase = "/vnc" -}}
 {{- end -}}
 {{- $vncTls := $vncIngress.tls | default dict -}}
-{{- $tlsEnabled := or ($vncTls.enabled) ($vncTls.secretName) ($vncTls.certResolver) -}}
+{{- $tlsEnabled := or (default false $vncTls.enabled) (ne (default "" $vncTls.secretName) "") (ne (default "" $vncTls.certResolver) "") -}}
 {{- if not $tlsEnabled -}}
 {{- $globalTls := .Values.ingress.tls | default dict -}}
-{{- $tlsEnabled = or ($globalTls.enabled) ($globalTls.secretName) ($globalTls.certResolver) -}}
+{{- $tlsEnabled = or (default false $globalTls.enabled) (ne (default "" $globalTls.secretName) "") (ne (default "" $globalTls.certResolver) "") -}}
 {{- end -}}
 {{- $wsScheme := ternary "wss" "ws" $tlsEnabled -}}
 {{- $_ := set $workerVncConfig "vnc_ws" (printf "%s://%s%s/{port}/websockify" $wsScheme $vncHost $vncPathBase) -}}
@@ -44,10 +44,10 @@
 {{- $vncPathBase = "/vnc" -}}
 {{- end -}}
 {{- $vncTls := $vncIngress.tls | default dict -}}
-{{- $tlsEnabled := or ($vncTls.enabled) ($vncTls.secretName) ($vncTls.certResolver) -}}
+{{- $tlsEnabled := or (default false $vncTls.enabled) (ne (default "" $vncTls.secretName) "") (ne (default "" $vncTls.certResolver) "") -}}
 {{- if not $tlsEnabled -}}
 {{- $globalTls := .Values.ingress.tls | default dict -}}
-{{- $tlsEnabled = or ($globalTls.enabled) ($globalTls.secretName) ($globalTls.certResolver) -}}
+{{- $tlsEnabled = or (default false $globalTls.enabled) (ne (default "" $globalTls.secretName) "") (ne (default "" $globalTls.certResolver) "") -}}
 {{- end -}}
 {{- $httpScheme := ternary "https" "http" $tlsEnabled -}}
 {{- $_ := set $workerVncConfig "vnc_http" (printf "%s://%s%s/{port}/vnc.html" $httpScheme $vncHost $vncPathBase) -}}

--- a/deploy/helm/camo-fleet/templates/worker-vnc-ingressroute.yaml
+++ b/deploy/helm/camo-fleet/templates/worker-vnc-ingressroute.yaml
@@ -74,7 +74,7 @@ spec:
 {{- end }}
 {{- end }}
       services:
-{{- if .Values.workerVnc.traefikService.enabled }}
+{{- if $.Values.workerVnc.traefikService.enabled }}
         - kind: TraefikService
           name: {{ printf "%s-%d" $serviceName $port }}
 {{- else }}


### PR DESCRIPTION
## Summary
- fix worker VNC ingress route template to access root values when rendering services
- ensure TLS detection in control ConfigMap remains boolean when deriving VNC URLs

## Testing
- `helm template camofleet deploy/helm/camo-fleet --set ingress.enabled=true --set ingress.host=example.com --set workerVnc.ingressRoute.enabled=true --api-versions traefik.io/v1alpha1`

------
https://chatgpt.com/codex/tasks/task_e_68d3f6fa3d3c832abed336a175eac5a3