### PR TITLE
Fix control deployment annotations placement

### DIFF
--- a/deploy/helm/camo-fleet/templates/control-deployment.yaml
+++ b/deploy/helm/camo-fleet/templates/control-deployment.yaml
@@ -15,11 +15,11 @@ spec:
       labels:
         app: {{ include "camofleet.control.fullname" . }}
 {{ include "camofleet.selectorLabels" . | indent 8 }}
-        annotations:
-          checksum/control-config: {{ include (print $.Template.BasePath "/control-configmap.yaml") . | sha256sum }}
-          {{- with .Values.control.podAnnotations }}
-            {{ toYaml . | indent 8 }}
-          {{- end }}
+      annotations:
+        checksum/control-config: {{ include (print $.Template.BasePath "/control-configmap.yaml") . | sha256sum }}
+{{- with .Values.control.podAnnotations }}
+{{ toYaml . | nindent 8 }}
+{{- end }}
     spec:
 {{ include "camofleet.imagePullSecrets" . | indent 6 }}
       containers:


### PR DESCRIPTION
## Summary
- ensure control Deployment annotations are defined on the pod template metadata instead of as labels
- keep optional user-provided pod annotations correctly indented with `nindent`

## Testing
- helm template camofleet deploy/helm/camo-fleet --namespace camofleet --set ingress.enabled=false --set workerVnc.ingressRoute.enabled=false --set workerVnc.traefikService.enabled=false

------
https://chatgpt.com/codex/tasks/task_e_68d3fd633570832a9d56af2614ad9fa5