### PR TITLE
Handle VNC identifier from path params

### DIFF
--- a/worker-vnc/tests/test_identifiers.py
+++ b/worker-vnc/tests/test_identifiers.py
@@ -78,6 +78,16 @@ def test_extract_identifier_uses_path_as_last_resort() -> None:
     assert extract_identifier(request) == 6904
 
 
+def test_extract_identifier_uses_path_params() -> None:
+    request = SimpleNamespace(
+        headers={},
+        query_params={},
+        path_params={"identifier": "6905"},
+        url=DummyUrl(path="/"),
+    )
+    assert extract_identifier(request) == 6905
+
+
 def test_extract_identifier_returns_none_when_missing() -> None:
     request = SimpleNamespace(headers={}, query_params={}, url=DummyUrl(path="/"))
     assert extract_identifier(request) is None


### PR DESCRIPTION
## Summary
- allow the VNC identifier extractor to read FastAPI path parameters in addition to headers, query params and URL paths
- normalize identifier candidates so string and integer sources are handled uniformly
- add a unit test that covers extracting identifiers from `path_params`

## Testing
- pytest worker-vnc/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d50df1e6cc832ab354ef3bd430142f