### PR TITLE
Ensure shared utilities importable from service packages

### DIFF
--- a/control-plane/camofleet_control/main.py
+++ b/control-plane/camofleet_control/main.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import sys
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 from time import perf_counter
 from typing import Any
 from urllib.parse import parse_qs, urlparse, urlunparse
 
 import httpx
+import websockets
 from fastapi import (
     Depends,
     FastAPI,
@@ -29,9 +32,6 @@ from prometheus_client import (
     Histogram,
     generate_latest,
 )
-import websockets
-
-from shared import __version__, bridge_websocket
 
 from .config import ControlSettings, WorkerConfig, load_settings
 from .models import (
@@ -41,6 +41,17 @@ from .models import (
     WorkerStatus,
 )
 from .service import aclose_worker_clients, worker_client
+
+try:  # pragma: no cover - executed only in developer environments
+    from shared import __version__, bridge_websocket
+except ModuleNotFoundError:  # pragma: no cover - fallback when ``shared`` isn't installed
+    repo_root = Path(__file__).resolve().parents[2]
+    shared_dir = repo_root / "shared"
+    if shared_dir.exists():
+        root_str = str(repo_root)
+        if root_str not in sys.path:
+            sys.path.insert(0, root_str)
+    from shared import __version__, bridge_websocket
 
 LOGGER = logging.getLogger(__name__)
 

--- a/runner/camoufox_runner/main.py
+++ b/runner/camoufox_runner/main.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import logging
+import sys
+from pathlib import Path
 
 from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from playwright.async_api import async_playwright
 from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
-
-from shared import __version__
 
 from .config import RunnerSettings, load_settings
 from .models import (
@@ -19,6 +19,17 @@ from .models import (
     SessionDetail,
 )
 from .sessions import SessionManager, VNCUnavailableError
+
+try:  # pragma: no cover - executed only in developer environments
+    from shared import __version__
+except ModuleNotFoundError:  # pragma: no cover - fallback when ``shared`` isn't installed
+    repo_root = Path(__file__).resolve().parents[2]
+    shared_dir = repo_root / "shared"
+    if shared_dir.exists():
+        root_str = str(repo_root)
+        if root_str not in sys.path:
+            sys.path.insert(0, root_str)
+    from shared import __version__
 
 LOGGER = logging.getLogger(__name__)
 

--- a/worker/camofleet_worker/main.py
+++ b/worker/camofleet_worker/main.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import logging
+import sys
 import uuid
+from pathlib import Path
 
 import httpx
+import websockets
 from fastapi import (
     Depends,
     FastAPI,
@@ -17,9 +20,6 @@ from fastapi import (
 )
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
-import websockets
-
-from shared import __version__, bridge_websocket
 
 from .config import WorkerSettings, load_settings
 from .models import (
@@ -30,6 +30,17 @@ from .models import (
     SessionStatus,
 )
 from .runner_client import RunnerClient
+
+try:  # pragma: no cover - executed only in developer environments
+    from shared import __version__, bridge_websocket
+except ModuleNotFoundError:  # pragma: no cover - fallback when ``shared`` isn't installed
+    repo_root = Path(__file__).resolve().parents[2]
+    shared_dir = repo_root / "shared"
+    if shared_dir.exists():
+        root_str = str(repo_root)
+        if root_str not in sys.path:
+            sys.path.insert(0, root_str)
+    from shared import __version__, bridge_websocket
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- add a guarded fallback in the control-plane, worker, and runner services to add the repository root to `sys.path` when the shared module is not installed
- keep import sections orderly after introducing the fallback logic

## Testing
- pytest control-plane/tests -q
- pytest worker/tests -q
- pytest runner/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d5415abeec832a84b7b1c6825a53bd