### PR TITLE
Ensure VNC WebSocket URLs carry target port

### DIFF
--- a/runner/camoufox_runner/sessions.py
+++ b/runner/camoufox_runner/sessions.py
@@ -580,6 +580,10 @@ class SessionManager:
                 self._settings.vnc_ws_base,
                 slot.ws_port,
                 "/websockify",
+                query_params={
+                    "path": "websockify",
+                    "target_port": str(slot.ws_port),
+                },
             )
 
             return VncSession(

--- a/runner/tests/test_vnc_public_url.py
+++ b/runner/tests/test_vnc_public_url.py
@@ -57,6 +57,25 @@ def test_compose_public_url_with_gateway_existing_prefix(manager: SessionManager
     assert query["target_port"] == ["6930"]
 
 
+def test_compose_public_url_includes_target_port_for_websocket(
+    manager: SessionManager,
+) -> None:
+    result = manager._compose_public_url(
+        "ws://localhost:6080/vnc",
+        6930,
+        "/websockify",
+        query_params={"path": "websockify", "target_port": "6930"},
+    )
+
+    parsed = urlparse(result)
+    assert parsed.scheme == "ws"
+    assert parsed.netloc == "localhost:6080"
+    assert parsed.path == "/vnc/websockify"
+    query = parse_qs(parsed.query)
+    assert query["path"] == ["vnc/websockify"]
+    assert query["target_port"] == ["6930"]
+
+
 def test_compose_public_url_preserves_existing_target(manager: SessionManager) -> None:
     result = manager._compose_public_url(
         "http://localhost:6080/vnc?target_port=1234",


### PR DESCRIPTION
## Summary
- include the target_port query parameter when generating VNC WebSocket embed URLs so the gateway can always route to the correct session
- add a regression test to verify the composed WebSocket URL preserves the target_port information

## Testing
- PYTHONPATH=. pytest tests/test_vnc_public_url.py

------
https://chatgpt.com/codex/tasks/task_e_68d5d7bb34ec832a89daec31a89a11f8