### PR TITLE
Fix VNC override handling in control plane

### DIFF
--- a/control-plane/tests/test_vnc_overrides.py
+++ b/control-plane/tests/test_vnc_overrides.py
@@ -1,0 +1,39 @@
+import pytest
+
+from camofleet_control.config import WorkerConfig
+from camofleet_control.main import apply_vnc_overrides
+
+
+@pytest.fixture(name="worker")
+def fixture_worker() -> WorkerConfig:
+    return WorkerConfig(
+        name="worker-vnc",
+        url="http://worker",
+        supports_vnc=True,
+        vnc_http="https://public.example/vnc/{id}",
+        vnc_ws="wss://public.example/websockify?token={id}",
+    )
+
+
+def test_apply_vnc_overrides_merges_paths_and_query(worker: WorkerConfig) -> None:
+    payload = {
+        "http": "http://127.0.0.1:6930/vnc.html?path=websockify&target_port=6930",
+        "ws": "ws://127.0.0.1:6930/websockify?target_port=6930",
+        "password_protected": False,
+    }
+
+    result = apply_vnc_overrides(worker, "session-123", payload)
+
+    assert result["http"] == (
+        "https://public.example/vnc/session-123/vnc.html?path=websockify&target_port=6930"
+    )
+    assert result["ws"] == (
+        "wss://public.example/websockify?token=session-123&target_port=6930"
+    )
+    assert result["password_protected"] is False
+
+
+def test_apply_vnc_overrides_handles_missing_payload(worker: WorkerConfig) -> None:
+    result = apply_vnc_overrides(worker, "session-456", None)
+
+    assert result == {}


### PR DESCRIPTION
## Summary
- apply configured VNC override templates when the control plane returns session descriptors
- merge runner-provided query parameters into the overridden URLs so the viewer keeps working
- add unit coverage around the override helper

## Testing
- pytest tests/test_vnc_overrides.py

------
https://chatgpt.com/codex/tasks/task_e_68d7560ff604832aa1f49cf63124be84