### PR TITLE
Fix public VNC overrides end-to-end

### DIFF
--- a/control-plane/tests/test_vnc_overrides.py
+++ b/control-plane/tests/test_vnc_overrides.py
@@ -1,0 +1,39 @@
+import pytest
+
+from camofleet_control.config import WorkerConfig
+from camofleet_control.main import apply_vnc_overrides
+
+
+@pytest.fixture(name="worker")
+def fixture_worker() -> WorkerConfig:
+    return WorkerConfig(
+        name="worker-vnc",
+        url="http://worker",
+        supports_vnc=True,
+        vnc_http="https://public.example/vnc/{id}",
+        vnc_ws="wss://public.example/websockify?token={id}",
+    )
+
+
+def test_apply_vnc_overrides_merges_paths_and_query(worker: WorkerConfig) -> None:
+    payload = {
+        "http": "http://127.0.0.1:6930/vnc.html?path=websockify&target_port=6930",
+        "ws": "ws://127.0.0.1:6930/websockify?target_port=6930",
+        "password_protected": False,
+    }
+
+    result = apply_vnc_overrides(worker, "session-123", payload)
+
+    assert result["http"] == (
+        "https://public.example/vnc/session-123/vnc.html?path=websockify&target_port=6930"
+    )
+    assert result["ws"] == (
+        "wss://public.example/websockify?token=session-123&target_port=6930"
+    )
+    assert result["password_protected"] is False
+
+
+def test_apply_vnc_overrides_handles_missing_payload(worker: WorkerConfig) -> None:
+    result = apply_vnc_overrides(worker, "session-456", None)
+
+    assert result == {}

--- a/vnc-gateway/tests/test_urls.py
+++ b/vnc-gateway/tests/test_urls.py
@@ -1,4 +1,8 @@
-from camofleet_vnc_gateway.main import _build_upstream_url, _join_paths
+from camofleet_vnc_gateway.main import (
+    _build_upstream_url,
+    _join_paths,
+    _normalise_client_path,
+)
 
 
 def test_build_upstream_url_with_prefix() -> None:
@@ -17,3 +21,17 @@ def test_build_upstream_url_with_prefix() -> None:
 def test_join_paths_handles_root() -> None:
     assert _join_paths("", "/websockify") == "/websockify"
     assert _join_paths("/prefix", "/") == "/prefix"
+
+
+def test_normalise_client_path_preserves_static_assets() -> None:
+    assert _normalise_client_path("/core/rfb.js") == "/core/rfb.js"
+    assert _normalise_client_path("/") == "/"
+
+
+def test_normalise_client_path_strips_session_segment() -> None:
+    uuid_segment = "ea4100ce-15a6-44b3-ab81-b5a180159653"
+    assert _normalise_client_path(f"/{uuid_segment}/vnc.html") == "/vnc.html"
+    assert (
+        _normalise_client_path(f"/{uuid_segment}/core/rfb.js")
+        == "/core/rfb.js"
+    )


### PR DESCRIPTION
## Summary
- apply configured VNC override templates when the control plane returns session descriptors
- merge runner-provided query parameters into the overridden URLs so the viewer keeps working
- add unit coverage around the override helper
- strip session UUID path segments at the VNC gateway so requests for noVNC assets resolve via ingress overrides

## Testing
- pytest tests/test_vnc_overrides.py
- pytest tests/test_urls.py

------
https://chatgpt.com/codex/tasks/task_e_68d7560ff604832aa1f49cf63124be84