### PR TITLE
Ensure VNC target ports propagate through ingress overrides

### DIFF
--- a/control-plane/tests/test_vnc_overrides.py
+++ b/control-plane/tests/test_vnc_overrides.py
@@ -1,7 +1,10 @@
+from urllib.parse import parse_qs, urlparse
+
 import pytest
 
 from camofleet_control.config import WorkerConfig
 from camofleet_control.main import apply_vnc_overrides
+from camoufox_runner.sessions import SessionManager
 
 
 @pytest.fixture(name="worker")
@@ -37,3 +40,33 @@ def test_apply_vnc_overrides_handles_missing_payload(worker: WorkerConfig) -> No
     result = apply_vnc_overrides(worker, "session-456", None)
 
     assert result == {}
+
+
+def test_apply_vnc_overrides_retains_target_port_from_runner(worker: WorkerConfig) -> None:
+    manager = SessionManager.__new__(SessionManager)  # type: ignore[call-arg]
+
+    http_payload = manager._compose_public_url(  # type: ignore[attr-defined]
+        "http://127.0.0.1:6930",
+        6930,
+        "/vnc.html",
+        query_params={"path": "websockify"},
+    )
+    ws_payload = manager._compose_public_url(  # type: ignore[attr-defined]
+        "ws://127.0.0.1:6930",
+        6930,
+        "/websockify",
+    )
+
+    payload = {
+        "http": http_payload,
+        "ws": ws_payload,
+        "password_protected": False,
+    }
+
+    result = apply_vnc_overrides(worker, "session-789", payload)
+
+    http_query = parse_qs(urlparse(result["http"]).query)
+    ws_query = parse_qs(urlparse(result["ws"]).query)
+
+    assert http_query["target_port"] == ["6930"]
+    assert ws_query["target_port"] == ["6930"]

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -42,7 +42,9 @@ Open `my-values.yaml` and adjust the options that differ in your environment:
       ws: wss://camofleet.services.synestra.tech/websockify?token={id}
       http: https://camofleet.services.synestra.tech/vnc/{id}
   ```
-  Эти значения попадут в `CONTROL_WORKERS`, поэтому UI и control-plane будут возвращать корректные публичные URL для noVNC.
+  Эти значения попадут в `CONTROL_WORKERS`, поэтому UI и control-plane будут возвращать корректные публичные URL для noVNC. Не
+  убирайте суффикс `/vnc` — runner и VNC-gateway полагаются на него, чтобы прокидывать `target_port` и корректно выбирать порт
+  вебсокета.
 - **`control.config.workers`** – оставьте `null`, чтобы Helm автоматически добавил сервисы `camofleet-worker` и `camofleet-worker-vnc`. Меняйте список только если подключаете внешние воркеры или меняете имена сервисов.
 
 Save the file when you are done.

--- a/deploy/helm/camofleet/templates/worker-vnc-deployment.yaml
+++ b/deploy/helm/camofleet/templates/worker-vnc-deployment.yaml
@@ -56,9 +56,9 @@ spec:
             - name: RUNNER_PORT
               value: "{{ .Values.workerVnc.runnerPort }}"
             - name: RUNNER_VNC_WS_BASE
-              value: ws://localhost:{{ .Values.workerVnc.gatewayPort }}
+              value: ws://localhost:{{ .Values.workerVnc.gatewayPort }}/vnc
             - name: RUNNER_VNC_HTTP_BASE
-              value: http://localhost:{{ .Values.workerVnc.gatewayPort }}
+              value: http://localhost:{{ .Values.workerVnc.gatewayPort }}/vnc
             - name: RUNNER_VNC_PORT_MIN
               value: "{{ .Values.workerVnc.vncPortRange.raw.min }}"
             - name: RUNNER_VNC_PORT_MAX
@@ -84,12 +84,14 @@ spec:
           image: {{ include "camofleet.image" (dict "Values" .Values "repository" .Values.workerVnc.gatewayImage.repository "tag" .Values.workerVnc.gatewayImage.tag) }}
           imagePullPolicy: {{ .Values.workerVnc.gatewayImage.pullPolicy }}
           env:
-            - name: VNC_DEFAULT_HOST
-              value: 127.0.0.1
-            - name: VNC_WEB_RANGE
-              value: {{ printf "%d-%d" $wsMin $wsMax }}
-            - name: VNC_BASE_PORT
-              value: "{{ .Values.workerVnc.vncPortRange.raw.min }}"
+            - name: VNCGATEWAY_PORT
+              value: "{{ .Values.workerVnc.gatewayPort }}"
+            - name: VNCGATEWAY_RUNNER_HOST
+              value: localhost
+            - name: VNCGATEWAY_MIN_PORT
+              value: "{{ .Values.workerVnc.vncPortRange.ws.min }}"
+            - name: VNCGATEWAY_MAX_PORT
+              value: "{{ .Values.workerVnc.vncPortRange.ws.max }}"
 {{- with .Values.workerVnc.gatewayExtraEnv }}
 {{ toYaml . | indent 12 }}
 {{- end }}

--- a/deploy/helm/camofleet/values.yaml
+++ b/deploy/helm/camofleet/values.yaml
@@ -100,5 +100,8 @@ workerVnc:
   extraEnv: []
   sessionDefaults: {}
   controlOverrides:
+    # The runner always advertises gateway URLs under the /vnc prefix. Keep
+    # that suffix when overriding the hosts so that target_port hints continue
+    # to work through Traefik.
     ws: null
     http: null

--- a/runner/camoufox_runner/sessions.py
+++ b/runner/camoufox_runner/sessions.py
@@ -690,7 +690,7 @@ class SessionManager:
                     adjusted_query_params["path"] = path_value
         if adjusted_query_params:
             query_items.extend(adjusted_query_params.items())
-        if override_port is not None and not any(key == "target_port" for key, _ in query_items):
+        if not any(key == "target_port" for key, _ in query_items):
             query_items.append(("target_port", str(port)))
         query = urlencode(query_items)
         return urlunparse((scheme, netloc, combined_path, "", query, ""))

--- a/runner/tests/test_vnc_public_url.py
+++ b/runner/tests/test_vnc_public_url.py
@@ -20,7 +20,7 @@ def test_compose_public_url_with_dynamic_ports(manager: SessionManager) -> None:
         query_params={"path": "websockify"},
     )
 
-    assert result == "http://localhost:6930/vnc.html?path=websockify"
+    assert result == "http://localhost:6930/vnc.html?path=websockify&target_port=6930"
 
 
 def test_compose_public_url_with_gateway(manager: SessionManager) -> None:


### PR DESCRIPTION
## Summary
- ensure the runner always preserves target_port hints in generated VNC URLs and cover the behaviour with new tests
- switch the worker-vnc Helm deployment to the new gateway environment variables and include the /vnc prefix in runner bases
- document the required /vnc suffix for public overrides so operators keep the gateway routing intact

## Testing
- pytest control-plane/tests/test_vnc_overrides.py runner/tests/test_vnc_public_url.py


------
https://chatgpt.com/codex/tasks/task_e_68d7756a5c44832aa236525ebbe195c7