### PR TITLE
Ensure target_port is always appended to VNC URLs

### DIFF
--- a/control-plane/tests/test_vnc_overrides.py
+++ b/control-plane/tests/test_vnc_overrides.py
@@ -37,3 +37,22 @@ def test_apply_vnc_overrides_handles_missing_payload(worker: WorkerConfig) -> No
     result = apply_vnc_overrides(worker, "session-456", None)
 
     assert result == {}
+
+
+def test_apply_vnc_overrides_preserves_target_port(worker: WorkerConfig) -> None:
+    payload = {
+        # Runner originally builds this from a loopback URL without ``target_port``;
+        # ensure we surface the propagated value after overrides are applied.
+        "http": "http://127.0.0.1:6930/vnc.html?path=websockify&target_port=6930",
+        "ws": "ws://127.0.0.1:6930/websockify?target_port=6930",
+        "password_protected": False,
+    }
+
+    result = apply_vnc_overrides(worker, "session-789", payload)
+
+    assert result["http"] == (
+        "https://public.example/vnc/session-789/vnc.html?path=websockify&target_port=6930"
+    )
+    assert result["ws"] == (
+        "wss://public.example/websockify?token=session-789&target_port=6930"
+    )

--- a/runner/camoufox/__init__.py
+++ b/runner/camoufox/__init__.py
@@ -1,0 +1,4 @@
+"""Test stub for camoufox module."""
+
+def launch_options(*, headless: bool | None = None) -> dict[str, object]:
+    return {"headless": headless}

--- a/runner/camoufox_runner/sessions.py
+++ b/runner/camoufox_runner/sessions.py
@@ -690,7 +690,7 @@ class SessionManager:
                     adjusted_query_params["path"] = path_value
         if adjusted_query_params:
             query_items.extend(adjusted_query_params.items())
-        if override_port is not None and not any(key == "target_port" for key, _ in query_items):
+        if not any(key == "target_port" for key, _ in query_items):
             query_items.append(("target_port", str(port)))
         query = urlencode(query_items)
         return urlunparse((scheme, netloc, combined_path, "", query, ""))

--- a/runner/tests/test_vnc_public_url.py
+++ b/runner/tests/test_vnc_public_url.py
@@ -20,7 +20,34 @@ def test_compose_public_url_with_dynamic_ports(manager: SessionManager) -> None:
         query_params={"path": "websockify"},
     )
 
-    assert result == "http://localhost:6930/vnc.html?path=websockify"
+    assert result == "http://localhost:6930/vnc.html?path=websockify&target_port=6930"
+
+
+def test_compose_public_url_adds_target_when_query_absent(manager: SessionManager) -> None:
+    result = manager._compose_public_url(
+        "http://localhost:6900",
+        6930,
+        "/websockify",
+    )
+
+    assert result == "http://localhost:6930/websockify?target_port=6930"
+
+
+def test_compose_public_url_adds_target_when_missing_in_base_query(
+    manager: SessionManager,
+) -> None:
+    result = manager._compose_public_url(
+        "http://localhost:6900?foo=bar",
+        6930,
+        "/vnc.html",
+        query_params={"path": "websockify"},
+    )
+
+    parsed = urlparse(result)
+    query = parse_qs(parsed.query)
+    assert query["foo"] == ["bar"]
+    assert query["path"] == ["websockify"]
+    assert query["target_port"] == ["6930"]
 
 
 def test_compose_public_url_with_gateway(manager: SessionManager) -> None:


### PR DESCRIPTION
## Summary
- ensure `_compose_public_url` appends a `target_port` query parameter whenever it is missing
- expand runner and control-plane tests to cover URLs without an initial `target_port`
- add a lightweight `camoufox` stub so unit tests can import the runner package without extra dependencies

## Testing
- `cd runner && PYTHONPATH=. pytest tests/test_vnc_public_url.py`
- `cd control-plane && PYTHONPATH=. pytest tests/test_vnc_overrides.py`


------
https://chatgpt.com/codex/tasks/task_e_68d77a4409a8832ab61f38b1d481c62f