### PR TITLE
Update Helm worker-vnc deployment for new VNC gateway env vars

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -43,6 +43,10 @@ Open `my-values.yaml` and adjust the options that differ in your environment:
       http: https://camofleet.services.synestra.tech/vnc/{id}
   ```
   Эти значения попадут в `CONTROL_WORKERS`, поэтому UI и control-plane будут возвращать корректные публичные URL для noVNC.
+- **VNC gateway** – порты, указанные в `workerVnc.gatewayPort` и `workerVnc.vncPortRange.ws`, автоматически попадают в
+  переменные окружения `VNCGATEWAY_PORT`, `VNCGATEWAY_MIN_PORT`, `VNCGATEWAY_MAX_PORT`. Шлюз внутри Pod обращается к runner-у
+  по `localhost` и проксирует публичный маршрут `/vnc`, поэтому дополнительные настройки требуются только в исключительных
+  сценариях.
 - **`control.config.workers`** – оставьте `null`, чтобы Helm автоматически добавил сервисы `camofleet-worker` и `camofleet-worker-vnc`. Меняйте список только если подключаете внешние воркеры или меняете имена сервисов.
 
 Save the file when you are done.

--- a/deploy/helm/camofleet/templates/worker-vnc-deployment.yaml
+++ b/deploy/helm/camofleet/templates/worker-vnc-deployment.yaml
@@ -84,12 +84,16 @@ spec:
           image: {{ include "camofleet.image" (dict "Values" .Values "repository" .Values.workerVnc.gatewayImage.repository "tag" .Values.workerVnc.gatewayImage.tag) }}
           imagePullPolicy: {{ .Values.workerVnc.gatewayImage.pullPolicy }}
           env:
-            - name: VNC_DEFAULT_HOST
-              value: 127.0.0.1
-            - name: VNC_WEB_RANGE
-              value: {{ printf "%d-%d" $wsMin $wsMax }}
-            - name: VNC_BASE_PORT
-              value: "{{ .Values.workerVnc.vncPortRange.raw.min }}"
+            - name: VNCGATEWAY_PORT
+              value: "{{ .Values.workerVnc.gatewayPort }}"
+            - name: VNCGATEWAY_RUNNER_HOST
+              value: "localhost"
+            - name: VNCGATEWAY_RUNNER_PATH_PREFIX
+              value: "/vnc"
+            - name: VNCGATEWAY_MIN_PORT
+              value: "{{ .Values.workerVnc.vncPortRange.ws.min }}"
+            - name: VNCGATEWAY_MAX_PORT
+              value: "{{ .Values.workerVnc.vncPortRange.ws.max }}"
 {{- with .Values.workerVnc.gatewayExtraEnv }}
 {{ toYaml . | indent 12 }}
 {{- end }}

--- a/deploy/helm/camofleet/values.yaml
+++ b/deploy/helm/camofleet/values.yaml
@@ -79,6 +79,7 @@ workerVnc:
     pullPolicy: IfNotPresent
   gatewayResources: {}
   gatewayExtraEnv: []
+  # Exposed through the gateway container as VNCGATEWAY_PORT and published by the Service/Ingress.
   gatewayPort: 6900
   image:
     repository: camofleet-worker
@@ -91,6 +92,8 @@ workerVnc:
     type: ClusterIP
     port: 8080
   vncPortRange:
+    # Controls the VNCGATEWAY_MIN_PORT/VNCGATEWAY_MAX_PORT environment variables for the
+    # gateway and the dynamic ports allocated by the runner container.
     ws:
       min: 6900
       max: 6904


### PR DESCRIPTION
## Summary
- replace deprecated VNC gateway environment variables with the new VNCGATEWAY_* settings in the worker-vnc Deployment
- document how workerVnc values populate the gateway container settings and clarify the mapping in values.yaml comments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d77b7b4ad8832ab950897fb180efd4