### PR TITLE
Ensure VNC base URLs include path suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ kubectl apply -k deploy/k8s
 
 | Переменная | Значение по умолчанию | Описание |
 | ---------- | --------------------- | -------- |
-| `RUNNER_VNC_WS_BASE` | `None` | Базовый адрес (со схемой и хостом) для генерации WebSocket URL предпросмотра. Порт будет подменён на выделенный для конкретной сессии. |
-| `RUNNER_VNC_HTTP_BASE` | `None` | Аналогично `RUNNER_VNC_WS_BASE`, но для noVNC iframe (`/vnc.html`). |
+| `RUNNER_VNC_WS_BASE` | `None` | Базовый адрес (со схемой и хостом) для генерации WebSocket URL предпросмотра. Должен оканчиваться на `/vnc`, порт будет подменён на выделенный для конкретной сессии. |
+| `RUNNER_VNC_HTTP_BASE` | `None` | Аналогично `RUNNER_VNC_WS_BASE`, но для noVNC iframe (`/vnc.html`); также требуется хвост `/vnc`. |
 | `RUNNER_VNC_DISPLAY_MIN` / `RUNNER_VNC_DISPLAY_MAX` | `100` / `199` | Диапазон виртуальных `DISPLAY`, выделяемых Xvfb. |
 | `RUNNER_VNC_PORT_MIN` / `RUNNER_VNC_PORT_MAX` | `5900` / `5999` | Диапазон TCP-портов для `x11vnc`. |
 | `RUNNER_VNC_WS_PORT_MIN` / `RUNNER_VNC_WS_PORT_MAX` | `6900` / `6999` | Диапазон TCP-портов для websockify/noVNC. |
@@ -158,7 +158,7 @@ kubectl apply -k deploy/k8s
 | `RUNNER_PREWARM_CHECK_INTERVAL_SECONDS` | `2.0` | Период проверки/дополнения пула тёплых резервов. |
 | `RUNNER_START_URL_WAIT` | `load` | Как долго ждать загрузку `start_url`: `none` (не грузить), `domcontentloaded`, `load`. При значении `none` навигация выполняется клиентом и стартовая вкладка останется пустой (включая VNC). |
 
-Порты и `DISPLAY` выделяются на каждую сессию. При использовании VNC gateway достаточно открыть сам шлюз (Docker: порт `6080`, Kubernetes: путь `/vnc`), однако внутри сети контейнеры должны иметь доступ к диапазону `RUNNER_VNC_WS_PORT_MIN`–`RUNNER_VNC_WS_PORT_MAX`. Для headless‑резервов prewarm используется `headless=true`.
+Порты и `DISPLAY` выделяются на каждую сессию. При использовании VNC gateway достаточно открыть сам шлюз (Docker: порт `6080`, Kubernetes: путь `/vnc`). Внешние URL должны указывать на базовый путь с `/vnc`, чтобы runner формировал `path=vnc/websockify` без дополнительных ingress middleware. Внутри сети контейнеры должны иметь доступ к диапазону `RUNNER_VNC_WS_PORT_MIN`–`RUNNER_VNC_WS_PORT_MAX`. Для headless‑резервов prewarm используется `headless=true`.
 
 ### Worker
 

--- a/deploy/helm/camofleet/templates/worker-vnc-deployment.yaml
+++ b/deploy/helm/camofleet/templates/worker-vnc-deployment.yaml
@@ -56,9 +56,9 @@ spec:
             - name: RUNNER_PORT
               value: "{{ .Values.workerVnc.runnerPort }}"
             - name: RUNNER_VNC_WS_BASE
-              value: ws://localhost:{{ .Values.workerVnc.gatewayPort }}
+              value: ws://localhost:{{ .Values.workerVnc.gatewayPort }}/vnc
             - name: RUNNER_VNC_HTTP_BASE
-              value: http://localhost:{{ .Values.workerVnc.gatewayPort }}
+              value: http://localhost:{{ .Values.workerVnc.gatewayPort }}/vnc
             - name: RUNNER_VNC_PORT_MIN
               value: "{{ .Values.workerVnc.vncPortRange.raw.min }}"
             - name: RUNNER_VNC_PORT_MAX

--- a/deploy/helm/camofleet/values.yaml
+++ b/deploy/helm/camofleet/values.yaml
@@ -103,5 +103,9 @@ workerVnc:
   extraEnv: []
   sessionDefaults: {}
   controlOverrides:
+    # Override the public URLs that the control plane returns in API responses.
+    # When setting custom values make sure the base paths already include the `/vnc`
+    # suffix (for example `wss://vnc.example.com/vnc`) so that runners can append
+    # `vnc/websockify` without requiring extra middleware on the ingress.
     ws: null
     http: null


### PR DESCRIPTION
## Summary
- append the required /vnc suffix to the runner VNC base URLs in the Helm worker-vnc deployment
- document the /vnc requirement in Helm values and the main README so public overrides are configured correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d77ce8e9f4832ab3fc191d60979b18