### PR TITLE
Handle missing VNC endpoints when applying overrides

### DIFF
--- a/control-plane/camofleet_control/main.py
+++ b/control-plane/camofleet_control/main.py
@@ -327,9 +327,24 @@ def apply_vnc_overrides(
     if not source:
         return {}
 
+    http_url = source.get("http")
+    ws_url = source.get("ws")
+
+    if not http_url and not ws_url:
+        return {}
+
     result: dict[str, Any] = {**source}
-    result["http"] = _build_public_vnc_url(worker.vnc_http, session_id, source.get("http"))
-    result["ws"] = _build_public_vnc_url(worker.vnc_ws, session_id, source.get("ws"))
+
+    if http_url:
+        result["http"] = _build_public_vnc_url(worker.vnc_http, session_id, http_url)
+    else:
+        result.pop("http", None)
+
+    if ws_url:
+        result["ws"] = _build_public_vnc_url(worker.vnc_ws, session_id, ws_url)
+    else:
+        result.pop("ws", None)
+
     return result
 
 

--- a/control-plane/tests/test_vnc_overrides.py
+++ b/control-plane/tests/test_vnc_overrides.py
@@ -39,6 +39,16 @@ def test_apply_vnc_overrides_handles_missing_payload(worker: WorkerConfig) -> No
     assert result == {}
 
 
+def test_apply_vnc_overrides_treats_falsy_endpoints_as_missing(
+    worker: WorkerConfig,
+) -> None:
+    payload = {"http": None, "ws": None, "password_protected": False}
+
+    result = apply_vnc_overrides(worker, "session-457", payload)
+
+    assert result == {}
+
+
 def test_apply_vnc_overrides_preserves_target_port(worker: WorkerConfig) -> None:
     payload = {
         # Runner originally builds this from a loopback URL without ``target_port``;


### PR DESCRIPTION
## Summary
- skip applying VNC overrides when both endpoints are falsy
- avoid rebuilding links without a fallback and drop empty endpoints from the payload
- add regression coverage for a payload with missing VNC endpoints

## Testing
- pytest control-plane

------
https://chatgpt.com/codex/tasks/task_e_68d78d619868832aa97f51ebb98ed396