### PR TITLE
Fix VNC gateway path prefix defaults and add VNC smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Camo-fleet/
    - Control-plane API: `http://localhost:9000`
    - Headless worker API: `http://localhost:8080`
    - VNC worker API: `http://localhost:8081`
-   - VNC gateway: `http://localhost:6080/vnc` — проксирует noVNC/ws трафик на нужный runner-порт
+  - VNC gateway: `http://localhost:6080` — проксирует noVNC/ws трафик на нужный runner-порт
 4. Тесты также можно прогнать внутри контейнеров:
    ```bash
    docker compose -f docker-compose.dev.yml run --rm --entrypoint pytest worker
@@ -105,7 +105,7 @@ Camo-fleet/
 3. После старта сервисов:
    - UI: `http://localhost:8080`
    - Control-plane API: `http://localhost:9000`
-   - VNC gateway: `http://localhost:6080/vnc` (UI подставляет `target_port` автоматически)
+  - VNC gateway: `http://localhost:6080` (UI подставляет `target_port` автоматически)
 4. Для остановки окружения выполните:
    ```powershell
    docker compose down
@@ -145,8 +145,8 @@ kubectl apply -k deploy/k8s
 
 | Переменная | Значение по умолчанию | Описание |
 | ---------- | --------------------- | -------- |
-| `RUNNER_VNC_WS_BASE` | `None` | Базовый адрес (со схемой и хостом) для генерации WebSocket URL предпросмотра. Должен оканчиваться на `/vnc`, порт будет подменён на выделенный для конкретной сессии. |
-| `RUNNER_VNC_HTTP_BASE` | `None` | Аналогично `RUNNER_VNC_WS_BASE`, но для noVNC iframe (`/vnc.html`); также требуется хвост `/vnc`. |
+| `RUNNER_VNC_WS_BASE` | `None` | Базовый адрес (со схемой и хостом) для генерации WebSocket URL предпросмотра. Путь добавляется автоматически, поэтому в большинстве случаев достаточно указать только хост и порт. |
+| `RUNNER_VNC_HTTP_BASE` | `None` | Аналогично `RUNNER_VNC_WS_BASE`, но для noVNC iframe (`/vnc.html`). |
 | `RUNNER_VNC_DISPLAY_MIN` / `RUNNER_VNC_DISPLAY_MAX` | `100` / `199` | Диапазон виртуальных `DISPLAY`, выделяемых Xvfb. |
 | `RUNNER_VNC_PORT_MIN` / `RUNNER_VNC_PORT_MAX` | `5900` / `5999` | Диапазон TCP-портов для `x11vnc`. |
 | `RUNNER_VNC_WS_PORT_MIN` / `RUNNER_VNC_WS_PORT_MAX` | `6900` / `6999` | Диапазон TCP-портов для websockify/noVNC. |
@@ -158,7 +158,7 @@ kubectl apply -k deploy/k8s
 | `RUNNER_PREWARM_CHECK_INTERVAL_SECONDS` | `2.0` | Период проверки/дополнения пула тёплых резервов. |
 | `RUNNER_START_URL_WAIT` | `load` | Как долго ждать загрузку `start_url`: `none` (не грузить), `domcontentloaded`, `load`. При значении `none` навигация выполняется клиентом и стартовая вкладка останется пустой (включая VNC). |
 
-Порты и `DISPLAY` выделяются на каждую сессию. При использовании VNC gateway достаточно открыть сам шлюз (Docker: порт `6080`, Kubernetes: путь `/vnc`). Внешние URL должны указывать на базовый путь с `/vnc`, чтобы runner формировал `path=vnc/websockify` без дополнительных ingress middleware. Внутри сети контейнеры должны иметь доступ к диапазону `RUNNER_VNC_WS_PORT_MIN`–`RUNNER_VNC_WS_PORT_MAX`. Для headless‑резервов prewarm используется `headless=true`.
+Порты и `DISPLAY` выделяются на каждую сессию. При использовании VNC gateway достаточно открыть сам шлюз (Docker: порт `6080`, Kubernetes: путь `/vnc`). Внешние URL должны указывать на маршрут, где доступен gateway (например, `/vnc/{id}`), runner автоматически добавит `vnc.html` и `websockify` к базовому пути. Внутри сети контейнеры должны иметь доступ к диапазону `RUNNER_VNC_WS_PORT_MIN`–`RUNNER_VNC_WS_PORT_MAX`. Для headless‑резервов prewarm используется `headless=true`.
 
 ### Worker
 

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -46,8 +46,9 @@ Open `my-values.yaml` and adjust the options that differ in your environment:
 - **VNC gateway** – порты, указанные в `workerVnc.gatewayPort` и `workerVnc.vncPortRange.ws`, автоматически попадают в
   переменные окружения `VNCGATEWAY_PORT`, `VNCGATEWAY_MIN_PORT`, `VNCGATEWAY_MAX_PORT`. Значение по умолчанию `gatewayPort=6080`
   специально вынесено за пределы WebSocket-пула `6900-6904`, а шаблон Helm прерывает установку, если вы зададите порт, который
-  пересекается с WebSocket- или raw VNC-диапазонами. Шлюз внутри Pod обращается к runner-у по `localhost` и проксирует публичный
-  маршрут `/vnc`, поэтому дополнительные настройки требуются только в исключительных сценариях.
+  пересекается с WebSocket- или raw VNC-диапазонами. Шлюз внутри Pod обращается к runner-у по `localhost` без дополнительного
+  префикса (если только вы не установите `workerVnc.runnerPathPrefix` вручную), поэтому дополнительные настройки требуются
+  только в исключительных сценариях.
 - **`control.config.workers`** – оставьте `null`, чтобы Helm автоматически добавил сервисы `camofleet-worker` и `camofleet-worker-vnc`. Меняйте список только если подключаете внешние воркеры или меняете имена сервисов.
 
 Save the file when you are done.

--- a/deploy/helm/camofleet/templates/worker-vnc-deployment.yaml
+++ b/deploy/helm/camofleet/templates/worker-vnc-deployment.yaml
@@ -29,6 +29,13 @@ spec:
 {{- $rawMax := int .Values.workerVnc.vncPortRange.raw.max }}
 {{- $httpPort := int .Values.workerVnc.service.port }}
 {{- $gatewayPort := int .Values.workerVnc.gatewayPort }}
+{{- $runnerPathPrefix := default "" .Values.workerVnc.runnerPathPrefix }}
+{{- if and $runnerPathPrefix (not (hasPrefix "/" $runnerPathPrefix)) }}
+{{- $runnerPathPrefix = printf "/%s" $runnerPathPrefix }}
+{{- end }}
+{{- if and (gt (len $runnerPathPrefix) 1) (hasSuffix "/" $runnerPathPrefix) }}
+{{- $runnerPathPrefix = trimSuffix "/" $runnerPathPrefix }}
+{{- end }}
 {{- if gt $wsMin $wsMax }}
   {{- fail (printf "workerVnc.vncPortRange.ws.min (%d) must be <= ws.max (%d)" $wsMin $wsMax) }}
 {{- end }}
@@ -59,9 +66,9 @@ spec:
             - name: RUNNER_PORT
               value: "{{ .Values.workerVnc.runnerPort }}"
             - name: RUNNER_VNC_WS_BASE
-              value: ws://localhost:{{ .Values.workerVnc.gatewayPort }}/vnc
+              value: ws://localhost:{{ .Values.workerVnc.gatewayPort }}{{ $runnerPathPrefix }}
             - name: RUNNER_VNC_HTTP_BASE
-              value: http://localhost:{{ .Values.workerVnc.gatewayPort }}/vnc
+              value: http://localhost:{{ .Values.workerVnc.gatewayPort }}{{ $runnerPathPrefix }}
             - name: RUNNER_VNC_PORT_MIN
               value: "{{ .Values.workerVnc.vncPortRange.raw.min }}"
             - name: RUNNER_VNC_PORT_MAX
@@ -92,7 +99,7 @@ spec:
             - name: VNCGATEWAY_RUNNER_HOST
               value: "localhost"
             - name: VNCGATEWAY_RUNNER_PATH_PREFIX
-              value: "/vnc"
+              value: "{{ $runnerPathPrefix }}"
             - name: VNCGATEWAY_MIN_PORT
               value: "{{ .Values.workerVnc.vncPortRange.ws.min }}"
             - name: VNCGATEWAY_MAX_PORT

--- a/deploy/helm/camofleet/values.yaml
+++ b/deploy/helm/camofleet/values.yaml
@@ -81,6 +81,7 @@ workerVnc:
   gatewayExtraEnv: []
   # Exposed through the gateway container as VNCGATEWAY_PORT and published by the Service/Ingress.
   gatewayPort: 6080
+  runnerPathPrefix: ""
   image:
     repository: camofleet-worker
     tag: latest
@@ -104,8 +105,8 @@ workerVnc:
   sessionDefaults: {}
   controlOverrides:
     # Override the public URLs that the control plane returns in API responses.
-    # When setting custom values make sure the base paths already include the `/vnc`
-    # suffix (for example `wss://vnc.example.com/vnc`) so that runners can append
-    # `vnc/websockify` without requiring extra middleware on the ingress.
+    # When setting custom values make sure the URLs resolve to the public route
+    # that exposes the VNC gateway. The runner appends ``vnc.html`` and
+    # ``websockify`` to these bases automatically.
     ws: null
     http: null

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -67,8 +67,8 @@ Example value:
     "name": "worker-vnc",
     "url": "http://camofleet-worker-vnc:8080",
     "supports_vnc": true,
-    "vnc_ws": "wss://camofleet.local/vnc",
-    "vnc_http": "https://camofleet.local/vnc"
+    "vnc_ws": "wss://camofleet.local",
+    "vnc_http": "https://camofleet.local"
   }
 ]
 ```
@@ -77,7 +77,8 @@ Runner автоматически подменяет порт в этих баз
 
 ### VNC gateway
 
-The gateway accepts HTTP и WebSocket запросы на `/vnc` и перенаправляет их на runner. Основные
+The gateway accepts HTTP и WebSocket запросы и перенаправляет их на runner без добавления
+дополнительного префикса. Основные
 переменные окружения:
 
 - `VNCGATEWAY_RUNNER_HOST` — DNS-имя сервиса с runner-vnc (по умолчанию `camofleet-worker-vnc`).

--- a/deploy/k8s/worker-vnc.deployment.yaml
+++ b/deploy/k8s/worker-vnc.deployment.yaml
@@ -21,9 +21,9 @@ spec:
             - name: RUNNER_PORT
               value: "8070"
             - name: RUNNER_VNC_WS_BASE
-              value: wss://camofleet.local/vnc
+              value: wss://camofleet.local
             - name: RUNNER_VNC_HTTP_BASE
-              value: https://camofleet.local/vnc
+              value: https://camofleet.local
           ports:
             - containerPort: 8070
               name: runner-http

--- a/deploy/traefik/README.md
+++ b/deploy/traefik/README.md
@@ -41,7 +41,7 @@ kubectl describe ingressroute -n camofleet camofleet
 - `/` → `camofleet-camo-fleet-ui:80`
 - `/api` → `camofleet-camo-fleet-control:9000`
 - `/vnc` → `camofleet-camo-fleet-worker-vnc:6080` (контейнер gateway внутри worker отвечает за noVNC)
-- `/websockify` → middleware добавляет префикс `/vnc` и проксирует на `camofleet-camo-fleet-worker-vnc:6080`, чтобы внешние noVNC WebSocket-URL выглядели как `https://camofleet.services.synestra.tech/websockify?token=...`
+- `/websockify` → проксирование на `camofleet-camo-fleet-worker-vnc:6080` без дополнительного префикса, чтобы внешние noVNC WebSocket-URL выглядели как `https://camofleet.services.synestra.tech/websockify?token=...`
 
 ## Remove the publication
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,8 +16,8 @@ services:
       dockerfile: docker/Dockerfile.runner-vnc
     environment:
       RUNNER_PORT: 8070
-      RUNNER_VNC_WS_BASE: ws://localhost:6080/vnc
-      RUNNER_VNC_HTTP_BASE: http://localhost:6080/vnc
+      RUNNER_VNC_WS_BASE: ws://localhost:6080
+      RUNNER_VNC_HTTP_BASE: http://localhost:6080
     expose:
       - '8070'
     ports:
@@ -85,7 +85,7 @@ services:
         [
           {"name":"headless","url":"http://worker:8080","supports_vnc":false},
           {"name":"vnc","url":"http://worker-vnc:8080","supports_vnc":true,
-           "vnc_ws":"ws://localhost:6080/vnc","vnc_http":"http://localhost:6080/vnc"}
+           "vnc_ws":"ws://localhost:6080","vnc_http":"http://localhost:6080"}
         ]
     depends_on:
       - worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
       dockerfile: docker/Dockerfile.runner-vnc
     environment:
       RUNNER_PORT: 8070
-      RUNNER_VNC_WS_BASE: ws://localhost:6080/vnc
-      RUNNER_VNC_HTTP_BASE: http://localhost:6080/vnc
+      RUNNER_VNC_WS_BASE: ws://localhost:6080
+      RUNNER_VNC_HTTP_BASE: http://localhost:6080
     expose:
       - '8070'
 
@@ -66,7 +66,7 @@ services:
         [
           {"name":"headless","url":"http://worker:8080","supports_vnc":false},
           {"name":"vnc","url":"http://worker-vnc:8080","supports_vnc":true,
-           "vnc_ws":"ws://localhost:6080/vnc","vnc_http":"http://localhost:6080/vnc"}
+           "vnc_ws":"ws://localhost:6080","vnc_http":"http://localhost:6080"}
         ]
     depends_on:
       - worker

--- a/scripts/vnc_smoke_test.py
+++ b/scripts/vnc_smoke_test.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Smoke-test the VNC gateway via the public control-plane API.
+
+The script creates a VNC-enabled session, waits until the runner reports an
+HTTP viewer URL and then fetches the page to ensure the deployment proxies the
+request correctly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import urllib.response
+from typing import Any, Dict, Optional
+
+
+def _build_url(base: str, path: str) -> str:
+    base = base.rstrip("/")
+    suffix = path if path.startswith("/") else f"/{path}"
+    return f"{base}{suffix}"
+
+
+def _open_url(
+    request: urllib.request.Request,
+    *,
+    context: Optional[ssl.SSLContext],
+    timeout: float,
+) -> urllib.response.addinfourl:
+    if context is not None:
+        return urllib.request.urlopen(request, timeout=timeout, context=context)
+    return urllib.request.urlopen(request, timeout=timeout)
+
+
+def _api_request(
+    base_url: str,
+    path: str,
+    *,
+    method: str,
+    payload: Optional[Dict[str, Any]] = None,
+    context: Optional[ssl.SSLContext],
+    timeout: float,
+) -> Dict[str, Any]:
+    url = _build_url(base_url, path)
+    data: Optional[bytes] = None
+    headers = {"Content-Type": "application/json"}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with _open_url(request, context=context, timeout=timeout) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        try:
+            detail = exc.read().decode()
+        except Exception:  # pragma: no cover - defensive fallback
+            detail = exc.reason if isinstance(exc.reason, str) else repr(exc.reason)
+        raise SystemExit(f"{method} {url} failed: {exc.code} {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"{method} {url} failed: {exc}") from exc
+
+
+def _delete_session(
+    base_url: str,
+    worker: str,
+    session_id: str,
+    *,
+    context: Optional[ssl.SSLContext],
+    timeout: float,
+) -> None:
+    path = f"/sessions/{urllib.parse.quote(worker)}/{urllib.parse.quote(session_id)}"
+    request = urllib.request.Request(
+        _build_url(base_url, path),
+        method="DELETE",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        _open_url(request, context=context, timeout=timeout)
+    except Exception:
+        # Session deletion failures are not fatal for the smoke test, but we log
+        # them to stderr for visibility.
+        print(
+            f"Warning: failed to delete session {worker}/{session_id}",
+            file=sys.stderr,
+        )
+
+
+def _fetch_vnc_page(url: str, *, context: Optional[ssl.SSLContext], timeout: float) -> int:
+    request = urllib.request.Request(url)
+    try:
+        with _open_url(request, context=context, timeout=timeout) as response:
+            return getattr(response, "status", response.getcode())
+    except urllib.error.HTTPError as exc:
+        return exc.code
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"Failed to reach VNC page {url}: {exc}") from exc
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--api-base",
+        default="http://localhost:9000/api",
+        help="Base URL of the control-plane API (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--worker",
+        help="Prefer a specific worker when creating the session",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=2.0,
+        help="Seconds to wait between session status checks (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=90.0,
+        help="Overall timeout for session readiness in seconds (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--request-timeout",
+        type=float,
+        default=10.0,
+        help="Timeout in seconds for individual HTTP requests (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Disable TLS certificate verification",
+    )
+    parser.add_argument(
+        "--keep-session",
+        action="store_true",
+        help="Do not delete the created session when the test finishes",
+    )
+    args = parser.parse_args()
+
+    ssl_context = ssl._create_unverified_context() if args.insecure else None
+
+    payload: Dict[str, Any] = {"vnc": True, "headless": False}
+    if args.worker:
+        payload["worker"] = args.worker
+
+    session = _api_request(
+        args.api_base,
+        "/sessions",
+        method="POST",
+        payload=payload,
+        context=ssl_context,
+        timeout=args.request_timeout,
+    )
+    worker = session["worker"]
+    session_id = session["id"]
+
+    print(f"Created session {worker}/{session_id}")
+
+    vnc_http: Optional[str] = session.get("vnc", {}).get("http")
+    deadline = time.monotonic() + args.timeout
+    while not vnc_http and time.monotonic() < deadline:
+        time.sleep(args.poll_interval)
+        descriptor = _api_request(
+            args.api_base,
+            f"/sessions/{urllib.parse.quote(worker)}/{urllib.parse.quote(session_id)}",
+            method="GET",
+            context=ssl_context,
+            timeout=args.request_timeout,
+        )
+        vnc_http = descriptor.get("vnc", {}).get("http")
+
+    if not vnc_http:
+        if not args.keep_session:
+            _delete_session(
+                args.api_base,
+                worker,
+                session_id,
+                context=ssl_context,
+                timeout=args.request_timeout,
+            )
+        raise SystemExit("Timed out waiting for the session to expose a VNC URL")
+
+    print(f"Checking VNC viewer page: {vnc_http}")
+    status_code = _fetch_vnc_page(vnc_http, context=ssl_context, timeout=args.request_timeout)
+    if status_code != 200:
+        if not args.keep_session:
+            _delete_session(
+                args.api_base,
+                worker,
+                session_id,
+                context=ssl_context,
+                timeout=args.request_timeout,
+            )
+        raise SystemExit(f"Expected HTTP 200 from VNC page, received {status_code}")
+
+    print("VNC viewer page returned HTTP 200")
+
+    if not args.keep_session:
+        _delete_session(
+            args.api_base,
+            worker,
+            session_id,
+            context=ssl_context,
+            timeout=args.request_timeout,
+        )
+        print("Session deleted")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- make the VNC gateway runner path prefix configurable in the Helm chart and default it to empty so requests reach the runner root
- update accompanying manifests, docs, and docker-compose defaults to match the new prefix handling
- add a smoke-test script that provisions a VNC session via the API and validates the reported viewer URL

## Testing
- python -m compileall scripts/vnc_smoke_test.py

------
https://chatgpt.com/codex/tasks/task_e_68d7b0c71180832a9ad3061e3668219b