### PR TITLE
Disable IPv6 when launching runner browser servers

### DIFF
--- a/README copy.md
+++ b/README copy.md
@@ -240,6 +240,7 @@ cp .env.example .env
 | `RUNNER_PREWARM_VNC` | `1` | Количество тёплых резервов c VNC (Xvfb+x11vnc+websockify); автоматически отключается, если инструменты VNC недоступны в образе. |
 | `RUNNER_PREWARM_CHECK_INTERVAL_SECONDS` | `2.0` | Период проверки/дополнения пула тёплых резервов. |
 | `RUNNER_START_URL_WAIT` | `load` | Как долго ждать загрузку `start_url`: `none` (не грузить), `domcontentloaded`, `load`. При значении `none` навигация выполняется клиентом и стартовая вкладка останется пустой (включая VNC). |
+| `RUNNER_DISABLE_IPV6` | `true` | Отключает IPv6 в профиле Firefox (`network.dns.disableIPv6`), чтобы не зависеть от поддержки IPv6 в инфраструктуре. |
 
 Порты и `DISPLAY` выделяются на каждую сессию. Убедитесь, что выбранные диапазоны проброшены наружу (Docker: `6900-6999:6900-6999`, `5900-5999:5900-5999`; Kubernetes — отдельный Ingress/Service или hostNetwork). Для headless‑резервов prewarm используется `headless=true`.
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ kubectl apply -k deploy/k8s
 | `RUNNER_PREWARM_VNC` | `1` | Количество тёплых резервов c VNC (Xvfb+x11vnc+websockify); автоматически отключается, если инструменты VNC недоступны в образе. |
 | `RUNNER_PREWARM_CHECK_INTERVAL_SECONDS` | `2.0` | Период проверки/дополнения пула тёплых резервов. |
 | `RUNNER_START_URL_WAIT` | `load` | Как долго ждать загрузку `start_url`: `none` (не грузить), `domcontentloaded`, `load`. При значении `none` навигация выполняется клиентом и стартовая вкладка останется пустой (включая VNC). |
+| `RUNNER_DISABLE_IPV6` | `true` | Отключает IPv6 в профиле Firefox (`network.dns.disableIPv6`), чтобы не зависеть от поддержки IPv6 в инфраструктуре. |
 
 Порты и `DISPLAY` выделяются на каждую сессию. При использовании VNC gateway достаточно открыть сам шлюз (Docker: порт `6080`, Kubernetes: путь `/vnc`). По умолчанию публичные URL содержат префикс `/vnc` (например, `/vnc/{id}`), однако его можно поменять через `workerVnc.runnerPathPrefix` в Helm chart и соответствующие переменные окружения. Runner автоматически добавит `vnc.html` и `websockify` к базовому пути. Внутри сети контейнеры должны иметь доступ к диапазону `RUNNER_VNC_WS_PORT_MIN`–`RUNNER_VNC_WS_PORT_MAX`. Для headless‑резервов prewarm используется `headless=true`.
 

--- a/runner/src/camoufox_runner/config.py
+++ b/runner/src/camoufox_runner/config.py
@@ -39,6 +39,7 @@ class RunnerSettings(BaseSettings):
     vnc_web_assets_path: str | None = "/usr/share/novnc"
     vnc_startup_timeout_seconds: Annotated[float, Field(gt=0.0, le=30.0)] = 5.0
     start_url_wait: Literal["none", "domcontentloaded", "load"] = "load"
+    disable_ipv6: bool = True
 
     # Prewarm pool: keep a small number of ready-to-serve browser servers
     # Separate targets for headless (no VNC) and VNC sessions

--- a/runner/src/camoufox_runner/sessions.py
+++ b/runner/src/camoufox_runner/sessions.py
@@ -777,6 +777,9 @@ class SessionManager:
         """Spawn a Camoufox Playwright server for a session."""
 
         opts = launch_options(headless=headless)
+        if self._settings.disable_ipv6:
+            firefox_prefs = opts.setdefault("firefox_user_prefs", {})
+            firefox_prefs.setdefault("network.dns.disableIPv6", True)
         env_vars = {k: v for k, v in (opts.get("env") or {}).items() if v is not None}
         if display:
             env_vars["DISPLAY"] = display


### PR DESCRIPTION
## Summary
- add a runner setting that disables IPv6 in Firefox profiles by default
- set the Firefox `network.dns.disableIPv6` preference when launching Camoufox sessions
- document the new `RUNNER_DISABLE_IPV6` environment variable

## Testing
- pytest runner/tests -q *(fails: missing fastapi dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8810c54dc832aa2641b32abd4918d