### PR TITLE
Stop normalizing Start URL

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -201,7 +201,7 @@ export default function App(): JSX.Element {
         worker: form.worker || undefined,
         headless: form.headless,
         idle_ttl_seconds: form.idle,
-        start_url: form.startUrl || undefined,
+        start_url: form.startUrl === '' ? undefined : form.startUrl,
         start_url_wait: form.startUrlWait,
         labels,
         vnc: form.vnc,

--- a/ui/src/components/LaunchSessionForm.tsx
+++ b/ui/src/components/LaunchSessionForm.tsx
@@ -107,7 +107,8 @@ export function LaunchSessionForm({
       <label>
         Start URL (optional)
         <input
-          type="url"
+          type="text"
+          inputMode="url"
           placeholder="https://example.org"
           value={form.startUrl}
           onChange={(event) =>


### PR DESCRIPTION
## Summary
- stop mutating the Start URL before submitting so the backend receives exactly what the user entered

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d88f0e14ec832a8da31f8948016b45