### PR TITLE
Disable HTTP/3 to avoid TLS errors when preloading start URLs

### DIFF
--- a/README copy.md
+++ b/README copy.md
@@ -241,6 +241,7 @@ cp .env.example .env
 | `RUNNER_PREWARM_CHECK_INTERVAL_SECONDS` | `2.0` | Период проверки/дополнения пула тёплых резервов. |
 | `RUNNER_START_URL_WAIT` | `load` | Как долго ждать загрузку `start_url`: `none` (не грузить), `domcontentloaded`, `load`. При значении `none` навигация выполняется клиентом и стартовая вкладка останется пустой (включая VNC). |
 | `RUNNER_DISABLE_IPV6` | `true` | Отключает IPv6 в профиле Firefox (`network.dns.disableIPv6`), чтобы не зависеть от поддержки IPv6 в инфраструктуре. |
+| `RUNNER_DISABLE_HTTP3` | `true` | Запрещает HTTP/3 и 0-RTT в Firefox (`network.http.http3.enabled`, `network.http.http3.enable_0rtt`), чтобы избежать ошибок TLS в сетях без поддержки UDP/QUIC. |
 
 Порты и `DISPLAY` выделяются на каждую сессию. Убедитесь, что выбранные диапазоны проброшены наружу (Docker: `6900-6999:6900-6999`, `5900-5999:5900-5999`; Kubernetes — отдельный Ingress/Service или hostNetwork). Для headless‑резервов prewarm используется `headless=true`.
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ kubectl apply -k deploy/k8s
 | `RUNNER_PREWARM_CHECK_INTERVAL_SECONDS` | `2.0` | Период проверки/дополнения пула тёплых резервов. |
 | `RUNNER_START_URL_WAIT` | `load` | Как долго ждать загрузку `start_url`: `none` (не грузить), `domcontentloaded`, `load`. При значении `none` навигация выполняется клиентом и стартовая вкладка останется пустой (включая VNC). |
 | `RUNNER_DISABLE_IPV6` | `true` | Отключает IPv6 в профиле Firefox (`network.dns.disableIPv6`), чтобы не зависеть от поддержки IPv6 в инфраструктуре. |
+| `RUNNER_DISABLE_HTTP3` | `true` | Запрещает HTTP/3 и 0-RTT в Firefox (`network.http.http3.enabled`, `network.http.http3.enable_0rtt`), чтобы избежать ошибок TLS в сетях без поддержки UDP/QUIC. |
 
 Порты и `DISPLAY` выделяются на каждую сессию. При использовании VNC gateway достаточно открыть сам шлюз (Docker: порт `6080`, Kubernetes: путь `/vnc`). По умолчанию публичные URL содержат префикс `/vnc` (например, `/vnc/{id}`), однако его можно поменять через `workerVnc.runnerPathPrefix` в Helm chart и соответствующие переменные окружения. Runner автоматически добавит `vnc.html` и `websockify` к базовому пути. Внутри сети контейнеры должны иметь доступ к диапазону `RUNNER_VNC_WS_PORT_MIN`–`RUNNER_VNC_WS_PORT_MAX`. Для headless‑резервов prewarm используется `headless=true`.
 

--- a/runner/src/camoufox_runner/config.py
+++ b/runner/src/camoufox_runner/config.py
@@ -40,6 +40,7 @@ class RunnerSettings(BaseSettings):
     vnc_startup_timeout_seconds: Annotated[float, Field(gt=0.0, le=30.0)] = 5.0
     start_url_wait: Literal["none", "domcontentloaded", "load"] = "load"
     disable_ipv6: bool = True
+    disable_http3: bool = True
 
     # Prewarm pool: keep a small number of ready-to-serve browser servers
     # Separate targets for headless (no VNC) and VNC sessions

--- a/runner/src/camoufox_runner/sessions.py
+++ b/runner/src/camoufox_runner/sessions.py
@@ -777,9 +777,12 @@ class SessionManager:
         """Spawn a Camoufox Playwright server for a session."""
 
         opts = launch_options(headless=headless)
+        firefox_prefs = opts.setdefault("firefox_user_prefs", {})
         if self._settings.disable_ipv6:
-            firefox_prefs = opts.setdefault("firefox_user_prefs", {})
             firefox_prefs.setdefault("network.dns.disableIPv6", True)
+        if self._settings.disable_http3:
+            firefox_prefs.setdefault("network.http.http3.enabled", False)
+            firefox_prefs.setdefault("network.http.http3.enable_0rtt", False)
         env_vars = {k: v for k, v in (opts.get("env") or {}).items() if v is not None}
         if display:
             env_vars["DISPLAY"] = display


### PR DESCRIPTION
## Summary
- add a runner configuration flag that disables HTTP/3 and 0-RTT in Firefox so start URL preloads work behind UDP-restricted networks
- document the new RUNNER_DISABLE_HTTP3 environment variable alongside existing runner settings

## Testing
- pytest *(fails: missing optional test dependencies such as httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68d89239a32c832a919c95e266075e2c