### PR TITLE
Fix runner navigation for Start URLs without a scheme

### DIFF
--- a/runner/src/camoufox_runner/__init__.py
+++ b/runner/src/camoufox_runner/__init__.py
@@ -1,5 +1,16 @@
 """Camoufox runner package."""
 
-from .main import create_app
+from __future__ import annotations
+
+from typing import Any
+
+
+def create_app(*args: Any, **kwargs: Any):  # pragma: no cover - thin wrapper
+    """Import and invoke :func:`camoufox_runner.main.create_app` lazily."""
+
+    from .main import create_app as _create_app
+
+    return _create_app(*args, **kwargs)
+
 
 __all__ = ["create_app"]

--- a/runner/src/camoufox_runner/sessions.py
+++ b/runner/src/camoufox_runner/sessions.py
@@ -24,6 +24,7 @@ from playwright.async_api import Playwright
 
 from .config import RunnerSettings
 from .models import SessionDetail, SessionStatus, SessionSummary
+from .url_utils import navigable_start_url
 
 LOGGER = logging.getLogger(__name__)
 
@@ -373,7 +374,10 @@ class SessionManager:
             browser = await self._playwright.firefox.connect(handle.server.ws_endpoint)
             context = await browser.new_context()
             page = await context.new_page()
-            await page.goto(handle.start_url, wait_until=handle.start_url_wait)
+            await page.goto(
+                navigable_start_url(handle.start_url),
+                wait_until=handle.start_url_wait,
+            )
             handle.controller_browser = browser
             handle.controller_context = context
             handle.controller_page = page

--- a/runner/src/camoufox_runner/url_utils.py
+++ b/runner/src/camoufox_runner/url_utils.py
@@ -1,0 +1,37 @@
+"""Helpers for working with user-provided URLs."""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit, urlunsplit
+
+_SCHEME_ONLY_PROTOCOLS = {"about", "data", "file", "javascript", "mailto"}
+
+
+def navigable_start_url(raw_url: str, default_scheme: str = "https") -> str:
+    """Return a URL that Playwright can navigate to.
+
+    The control plane forwards the exact string the operator entered, which can
+    be a bare hostname like ``example.com``. Browsers require an explicit
+    scheme, so we infer a ``https://`` prefix when the value looks like a
+    hostname or host/path combination. Relative paths (``/foo`` or
+    ``./foo``) are returned untouched so callers can decide how to handle
+    them.
+    """
+
+    parts = urlsplit(raw_url)
+    if parts.scheme and ("://" in raw_url or parts.scheme in _SCHEME_ONLY_PROTOCOLS):
+        return raw_url
+
+    alt_source = raw_url if raw_url.startswith("//") else f"//{raw_url}"
+    alt_parts = urlsplit(alt_source)
+    if alt_parts.netloc and alt_parts.netloc not in {".", ".."}:
+        return urlunsplit(
+            (default_scheme, alt_parts.netloc, alt_parts.path, alt_parts.query, alt_parts.fragment)
+        )
+
+    if not parts.path or parts.path.startswith(("/", ".", "#")):
+        return raw_url
+
+    host, separator, remainder = parts.path.partition("/")
+    path = f"/{remainder}" if separator else ""
+    return urlunsplit((default_scheme, host, path, parts.query, parts.fragment))

--- a/runner/tests/test_start_url.py
+++ b/runner/tests/test_start_url.py
@@ -1,0 +1,25 @@
+import pytest
+
+from camoufox_runner.url_utils import navigable_start_url
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("https://example.com", "https://example.com"),
+        ("http://example.com", "http://example.com"),
+        ("bot.sannysoft.com", "https://bot.sannysoft.com"),
+        (
+            "bot.sannysoft.com/path?q=1#frag",
+            "https://bot.sannysoft.com/path?q=1#frag",
+        ),
+        ("//example.com/foo", "https://example.com/foo"),
+        ("localhost:9222", "https://localhost:9222"),
+        ("about:blank", "about:blank"),
+        ("data:text/plain,hello", "data:text/plain,hello"),
+        ("/relative", "/relative"),
+        ("./script.js", "./script.js"),
+    ],
+)
+def test_navigable_start_url(value: str, expected: str) -> None:
+    assert navigable_start_url(value) == expected

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -201,7 +201,7 @@ export default function App(): JSX.Element {
         worker: form.worker || undefined,
         headless: form.headless,
         idle_ttl_seconds: form.idle,
-        start_url: form.startUrl || undefined,
+        start_url: form.startUrl === '' ? undefined : form.startUrl,
         start_url_wait: form.startUrlWait,
         labels,
         vnc: form.vnc,

--- a/ui/src/components/LaunchSessionForm.tsx
+++ b/ui/src/components/LaunchSessionForm.tsx
@@ -107,7 +107,8 @@ export function LaunchSessionForm({
       <label>
         Start URL (optional)
         <input
-          type="url"
+          type="text"
+          inputMode="url"
           placeholder="https://example.org"
           value={form.startUrl}
           onChange={(event) =>


### PR DESCRIPTION
## Summary
- add a URL helper that infers an https:// scheme for bare hostnames before navigation
- use the helper in the runner bootstrap so Start URLs like bot.sannysoft.com open correctly
- make the runner package's create_app import lazy and add tests covering the helper

## Testing
- pytest runner/tests/test_start_url.py

------
https://chatgpt.com/codex/tasks/task_e_68d88f0e14ec832a8da31f8948016b45