### PR TITLE
Disable HTTP/3 and IPv6 prefs explicitly

### DIFF
--- a/runner/src/camoufox_runner/sessions.py
+++ b/runner/src/camoufox_runner/sessions.py
@@ -783,10 +783,10 @@ class SessionManager:
         opts = launch_options(headless=headless)
         firefox_prefs = opts.setdefault("firefox_user_prefs", {})
         if self._settings.disable_ipv6:
-            firefox_prefs.setdefault("network.dns.disableIPv6", True)
+            firefox_prefs["network.dns.disableIPv6"] = True
         if self._settings.disable_http3:
-            firefox_prefs.setdefault("network.http.http3.enabled", False)
-            firefox_prefs.setdefault("network.http.http3.enable_0rtt", False)
+            firefox_prefs["network.http.http3.enabled"] = False
+            firefox_prefs["network.http.http3.enable_0rtt"] = False
         env_vars = {k: v for k, v in (opts.get("env") or {}).items() if v is not None}
         if display:
             env_vars["DISPLAY"] = display


### PR DESCRIPTION
## Summary
- force Firefox profiles launched by the runner to disable IPv6 and HTTP/3 regardless of existing defaults

## Testing
- pytest runner/tests/test_start_url.py

------
https://chatgpt.com/codex/tasks/task_e_68d89a0d81e0832ab8402e06c5753900