### PR TITLE
Disable HTTP3 for runner pods in Helm chart

### DIFF
--- a/deploy/helm/camofleet/templates/worker-deployment.yaml
+++ b/deploy/helm/camofleet/templates/worker-deployment.yaml
@@ -30,6 +30,8 @@ spec:
           env:
             - name: RUNNER_PORT
               value: "{{ .Values.worker.runnerPort }}"
+            - name: RUNNER_DISABLE_HTTP3
+              value: "{{ ternary "true" "false" .Values.worker.disableHttp3 }}"
 {{- with .Values.worker.runnerExtraEnv }}
 {{ toYaml . | indent 12 }}
 {{- end }}

--- a/deploy/helm/camofleet/templates/worker-vnc-deployment.yaml
+++ b/deploy/helm/camofleet/templates/worker-vnc-deployment.yaml
@@ -65,6 +65,8 @@ spec:
           env:
             - name: RUNNER_PORT
               value: "{{ .Values.workerVnc.runnerPort }}"
+            - name: RUNNER_DISABLE_HTTP3
+              value: "{{ ternary "true" "false" .Values.workerVnc.disableHttp3 }}"
             - name: RUNNER_VNC_WS_BASE
               value: ws://localhost:{{ .Values.workerVnc.gatewayPort }}{{ $runnerPathPrefix }}
             - name: RUNNER_VNC_HTTP_BASE

--- a/deploy/helm/camofleet/values.yaml
+++ b/deploy/helm/camofleet/values.yaml
@@ -48,6 +48,7 @@ worker:
     tag: latest
     pullPolicy: IfNotPresent
   runnerResources: {}
+  disableHttp3: true
   runnerExtraEnv: []
   image:
     repository: camofleet-worker
@@ -72,6 +73,7 @@ workerVnc:
     tag: latest
     pullPolicy: IfNotPresent
   runnerResources: {}
+  disableHttp3: true
   runnerExtraEnv: []
   gatewayImage:
     repository: camofleet-vnc-gateway


### PR DESCRIPTION
## Summary
- expose a dedicated Helm value to toggle HTTP/3 support for runner containers
- set the default to disable HTTP/3 and pass it to both headless and VNC runner pods

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d89cdb71c0832a8d51e6ff94c6359c