### PR TITLE
Gracefully skip HTTP/2 probe when dependencies are missing

### DIFF
--- a/runner/tests/test_diagnostics.py
+++ b/runner/tests/test_diagnostics.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from camoufox_runner import diagnostics
+
+
+def test_probe_http2_skips_when_httpx_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(diagnostics, "httpx", None)
+
+    async def _run() -> diagnostics.ProbeOutcome:
+        return await diagnostics.probe_http2("https://example.org", timeout=1.0)
+
+    result = asyncio.run(_run())
+
+    assert result.status == "skipped"
+    assert "httpx is unavailable" in result.detail
+
+
+def test_probe_http2_skips_when_http2_dependencies_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyAsyncClient:
+        def __init__(self, *_, **__):
+            pass
+
+        async def __aenter__(self) -> DummyAsyncClient:
+            return self
+
+        async def __aexit__(self, *_) -> None:
+            return None
+
+        async def get(self, *_, **__):
+            raise AssertionError("HTTP request should not be performed when dependencies missing")
+
+    monkeypatch.setattr(diagnostics, "httpx", type("DummyHttpx", (), {"AsyncClient": DummyAsyncClient}))
+    monkeypatch.setattr(diagnostics, "_HTTP2_AVAILABLE", False)
+
+    async def _run() -> diagnostics.ProbeOutcome:
+        return await diagnostics.probe_http2("https://example.org", timeout=1.0)
+
+    result = asyncio.run(_run())
+
+    assert result.status == "skipped"
+    assert "HTTP/2 dependencies" in result.detail


### PR DESCRIPTION
## Summary
- make the runner's HTTP/2 diagnostics probe gracefully skip when httpx or its HTTP/2 extras are unavailable
- add regression tests covering the skip behaviour when dependencies cannot be imported

## Testing
- pytest runner/tests/test_diagnostics.py

------
https://chatgpt.com/codex/tasks/task_e_68d8ba41a0f8832a867515b68118ac85