### PR TITLE
Ensure runner installs HTTP/2 dependencies

### DIFF
--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pydantic>=2.7",
     "pydantic-settings>=2.2",
     "camoufox[geoip]>=0.4",
-    "httpx>=0.27",
+    "httpx[http2]>=0.27",
     "prometheus-client>=0.20",
     "aioquic>=1.2",
 ]


### PR DESCRIPTION
## Summary
- install httpx with the http2 extra so the runner bundles the h2 dependency required by the diagnostics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8f4039e38832a9fbe8e79282eb970