### PR TITLE
Force-disable HTTP/3 for Firefox runner sessions

### DIFF
--- a/docker/scripts/runner-entrypoint.sh
+++ b/docker/scripts/runner-entrypoint.sh
@@ -8,6 +8,22 @@ cleanup() {
 }
 trap cleanup EXIT
 
+normalize_bool() {
+  case "${1:-}" in
+    1|true|TRUE|True|yes|YES|on|ON)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if normalize_bool "${RUNNER_DISABLE_HTTP3:-}"; then
+  export MOZ_DISABLE_HTTP3=1
+  export MOZ_DISABLE_QUIC=1
+fi
+
 if [ "${RUNNER_VNC_LEGACY:-0}" = "1" ]; then
   /usr/local/bin/vnc-start.sh &
   VNC_PID=$!


### PR DESCRIPTION
## Summary
- export `MOZ_DISABLE_HTTP3`/`MOZ_DISABLE_QUIC` from the runner entrypoint when `RUNNER_DISABLE_HTTP3` is enabled so Firefox never negotiates HTTP/3
- normalise common truthy values before toggling the environment flags to make the behaviour robust for Helm and docker-compose deployments

## Testing
- `pytest runner/tests/test_sessions.py`


------
https://chatgpt.com/codex/tasks/task_e_68d9478faba8832ab039a32b360c0750