### PR TITLE
Disable WebRTC alongside HTTP/3 in runner pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ kubectl apply -k deploy/k8s
 | `RUNNER_START_URL_WAIT` | `load` | Как долго ждать загрузку `start_url`: `none` (не грузить), `domcontentloaded`, `load`. При значении `none` навигация выполняется клиентом и стартовая вкладка останется пустой (включая VNC). |
 | `RUNNER_DISABLE_IPV6` | `true` | Отключает IPv6 в профиле Firefox (`network.dns.disableIPv6`), чтобы не зависеть от поддержки IPv6 в инфраструктуре. |
 | `RUNNER_DISABLE_HTTP3` | `true` | Полностью отключает HTTP/3 в Firefox (`network.http.http3.enabled`, `network.http.http3.enable_0rtt`, `network.http.http3.enable_alt_svc`/`network.http.http3.alt_svc`, `network.http.http3.retry_different_host`, `MOZ_DISABLE_HTTP3`), чтобы избежать ошибок TLS (`PR_END_OF_FILE_ERROR`) в средах без поддержки UDP/QUIC. |
+| `RUNNER_DISABLE_WEBRTC` | `true` | Запрещает WebRTC в Firefox (`media.peerconnection.enabled=false`), исключая любые исходящие UDP-попытки (ICE/STUN) в кластерах с жёстким TCP-only egress. |
+| `MOZ_DISABLE_HTTP3` | `1`, если `RUNNER_DISABLE_HTTP3=true` | Передаётся напрямую Firefox-процессам и гарантирует отключение HTTP/3 ещё до инициализации профиля. |
 | `RUNNER_NETWORK_DIAGNOSTICS` | `["https://bot.sannysoft.com"]` | JSON-массив URL, которые runner проверяет при старте, фиксируя поддержку HTTP/2/HTTP/3 в текущей среде. |
 | `RUNNER_DIAGNOSTICS_TIMEOUT_SECONDS` | `8.0` | Таймаут одной проверки в секундах; полезно уменьшить в средах с ограниченным доступом наружу. |
 

--- a/deploy/helm/camofleet/templates/worker-deployment.yaml
+++ b/deploy/helm/camofleet/templates/worker-deployment.yaml
@@ -32,6 +32,12 @@ spec:
               value: "{{ .Values.worker.runnerPort }}"
             - name: RUNNER_DISABLE_HTTP3
               value: "{{ ternary "true" "false" .Values.worker.disableHttp3 }}"
+            {{- if .Values.worker.disableHttp3 }}
+            - name: MOZ_DISABLE_HTTP3
+              value: "1"
+            {{- end }}
+            - name: RUNNER_DISABLE_WEBRTC
+              value: "{{ ternary "true" "false" .Values.worker.disableWebrtc }}"
             - name: RUNNER_NETWORK_DIAGNOSTICS
               value: '{{ toJson .Values.worker.networkDiagnostics }}'
             - name: RUNNER_DIAGNOSTICS_TIMEOUT_SECONDS

--- a/deploy/helm/camofleet/templates/worker-vnc-deployment.yaml
+++ b/deploy/helm/camofleet/templates/worker-vnc-deployment.yaml
@@ -67,6 +67,12 @@ spec:
               value: "{{ .Values.workerVnc.runnerPort }}"
             - name: RUNNER_DISABLE_HTTP3
               value: "{{ ternary "true" "false" .Values.workerVnc.disableHttp3 }}"
+            {{- if .Values.workerVnc.disableHttp3 }}
+            - name: MOZ_DISABLE_HTTP3
+              value: "1"
+            {{- end }}
+            - name: RUNNER_DISABLE_WEBRTC
+              value: "{{ ternary "true" "false" .Values.workerVnc.disableWebrtc }}"
             - name: RUNNER_NETWORK_DIAGNOSTICS
               value: '{{ toJson .Values.workerVnc.networkDiagnostics }}'
             - name: RUNNER_DIAGNOSTICS_TIMEOUT_SECONDS

--- a/deploy/helm/camofleet/values.yaml
+++ b/deploy/helm/camofleet/values.yaml
@@ -48,8 +48,9 @@ worker:
     tag: latest
     pullPolicy: IfNotPresent
   runnerResources: {}
-  # Keep HTTP/3 disabled explicitly to avoid Firefox TLS handshake issues
+  # Keep HTTP/3 disabled and WebRTC off to avoid Firefox using UDP transports
   disableHttp3: true
+  disableWebrtc: true
   networkDiagnostics:
     - https://bot.sannysoft.com
   diagnosticsTimeoutSeconds: 8
@@ -77,8 +78,9 @@ workerVnc:
     tag: latest
     pullPolicy: IfNotPresent
   runnerResources: {}
-  # Keep HTTP/3 disabled explicitly to avoid Firefox TLS handshake issues
+  # Keep HTTP/3 disabled and WebRTC off to avoid Firefox using UDP transports
   disableHttp3: true
+  disableWebrtc: true
   networkDiagnostics:
     - https://bot.sannysoft.com
   diagnosticsTimeoutSeconds: 8

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -48,6 +48,8 @@ This creates deployments for headless и VNC воркеров (каждый — 
 - `WORKER_RUNNER_BASE_URL` — адрес sidecar runner'а (по умолчанию `http://localhost:8070`).
 - `WORKER_SUPPORTS_VNC` — флаг, который сигнализирует control-plane, что воркер умеет в VNC.
 - `RUNNER_VNC_WS_BASE` / `RUNNER_VNC_HTTP_BASE` — задаются только для runner-vnc и используются UI.
+- `RUNNER_DISABLE_HTTP3` / `MOZ_DISABLE_HTTP3` — отключают HTTP/3 и Alt-Svc апгрейды в Firefox, чтобы запросы шли по TCP (HTTP/2/1.1).
+- `RUNNER_DISABLE_WEBRTC` — запрещает WebRTC, исключая любые UDP-попытки из браузера внутри кластера.
 
 ### Control-plane
 

--- a/deploy/k8s/worker-vnc.deployment.yaml
+++ b/deploy/k8s/worker-vnc.deployment.yaml
@@ -20,10 +20,18 @@ spec:
           env:
             - name: RUNNER_PORT
               value: "8070"
+            - name: RUNNER_DISABLE_HTTP3
+              value: "true"
+            - name: MOZ_DISABLE_HTTP3
+              value: "1"
+            - name: RUNNER_DISABLE_WEBRTC
+              value: "true"
             - name: RUNNER_VNC_WS_BASE
               value: wss://camofleet.local
             - name: RUNNER_VNC_HTTP_BASE
               value: https://camofleet.local
+            - name: RUNNER_NETWORK_DIAGNOSTICS
+              value: '["https://bot.sannysoft.com"]'
           ports:
             - containerPort: 8070
               name: runner-http

--- a/deploy/k8s/worker.deployment.yaml
+++ b/deploy/k8s/worker.deployment.yaml
@@ -20,6 +20,14 @@ spec:
           env:
             - name: RUNNER_PORT
               value: "8070"
+            - name: RUNNER_DISABLE_HTTP3
+              value: "true"
+            - name: MOZ_DISABLE_HTTP3
+              value: "1"
+            - name: RUNNER_DISABLE_WEBRTC
+              value: "true"
+            - name: RUNNER_NETWORK_DIAGNOSTICS
+              value: '["https://bot.sannysoft.com"]'
           ports:
             - containerPort: 8070
               name: runner-http

--- a/runner/src/camoufox_runner/config.py
+++ b/runner/src/camoufox_runner/config.py
@@ -41,6 +41,7 @@ class RunnerSettings(BaseSettings):
     start_url_wait: Literal["none", "domcontentloaded", "load"] = "load"
     disable_ipv6: bool = True
     disable_http3: bool = True
+    disable_webrtc: bool = True
     network_diagnostics: list[str] = Field(default_factory=lambda: ["https://bot.sannysoft.com"])
     diagnostics_timeout_seconds: Annotated[float, Field(gt=0.0, le=60.0)] = 8.0
 

--- a/runner/src/camoufox_runner/sessions.py
+++ b/runner/src/camoufox_runner/sessions.py
@@ -803,6 +803,8 @@ class SessionManager:
             firefox_prefs["network.http.http3.enable_alt_svc"] = False
             firefox_prefs["network.http.http3.alt_svc"] = False
             firefox_prefs["network.http.http3.retry_different_host"] = False
+        if self._settings.disable_webrtc:
+            firefox_prefs["media.peerconnection.enabled"] = False
         env_vars = {k: v for k, v in (opts.get("env") or {}).items() if v is not None}
         if self._settings.disable_http3:
             # ``MOZ_DISABLE_HTTP3`` short-circuits the networking stack before

--- a/runner/tests/test_sessions.py
+++ b/runner/tests/test_sessions.py
@@ -88,6 +88,7 @@ def test_launch_browser_server_overrides_moz_disable_http3(monkeypatch):
 
     class DummySettings:
         disable_http3 = True
+        disable_webrtc = True
         disable_ipv6 = False
         vnc_display_min = 100
         vnc_display_max = 100
@@ -139,6 +140,7 @@ def test_launch_browser_server_overrides_moz_disable_http3(monkeypatch):
         prefs = config["firefoxUserPrefs"]
         assert prefs["network.http.http3.enable_alt_svc"] is False
         assert prefs["network.http.http3.alt_svc"] is False
+        assert prefs["media.peerconnection.enabled"] is False
 
     asyncio.run(run_test())
 
@@ -148,6 +150,7 @@ def test_disable_http3_drains_prewarmed(monkeypatch):
 
     class DummySettings:
         disable_http3 = False
+        disable_webrtc = True
         disable_ipv6 = False
         vnc_display_min = 100
         vnc_display_max = 100


### PR DESCRIPTION
## Summary
- add a runner setting that disables WebRTC and map it to the Firefox profile when HTTP/3 is disabled for k3s
- surface the new disableWebrtc flags through the Helm values and raw Kubernetes manifests alongside MOZ_DISABLE_HTTP3
- update the documentation to instruct operators to keep HTTP/3 and WebRTC disabled in UDP-restricted clusters

## Testing
- pytest runner/tests/test_sessions.py

------
https://chatgpt.com/codex/tasks/task_e_68d9478faba8832ab039a32b360c0750