### PR TITLE
Fix HTTP/3 preference key name

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ kubectl apply -k deploy/k8s
 | `RUNNER_PREWARM_CHECK_INTERVAL_SECONDS` | `2.0` | Период проверки/дополнения пула тёплых резервов. |
 | `RUNNER_START_URL_WAIT` | `load` | Как долго ждать загрузку `start_url`: `none` (не грузить), `domcontentloaded`, `load`. При значении `none` навигация выполняется клиентом и стартовая вкладка останется пустой (включая VNC). |
 | `RUNNER_DISABLE_IPV6` | `true` | Отключает IPv6 в профиле Firefox (`network.dns.disableIPv6`), чтобы не зависеть от поддержки IPv6 в инфраструктуре. |
-| `RUNNER_DISABLE_HTTP3` | `true` | Полностью отключает HTTP/3 в Firefox (`network.http.http3.enabled`, `network.http.http3.enable_0rtt`, `network.http.http3.enable_alt_svc`/`network.http.http3.alt_svc`, `network.http.http3.retry_different_host`, `MOZ_DISABLE_HTTP3`), чтобы избежать ошибок TLS (`PR_END_OF_FILE_ERROR`) в средах без поддержки UDP/QUIC. |
+| `RUNNER_DISABLE_HTTP3` | `true` | Полностью отключает HTTP/3 в Firefox (`network.http.http3.enable`, `network.http.http3.enable_0rtt`, `network.http.http3.enable_alt_svc`/`network.http.http3.alt_svc`, `network.http.http3.retry_different_host`, `MOZ_DISABLE_HTTP3`), чтобы избежать ошибок TLS (`PR_END_OF_FILE_ERROR`) в средах без поддержки UDP/QUIC. |
 | `RUNNER_DISABLE_WEBRTC` | `true` | Запрещает WebRTC в Firefox (`media.peerconnection.enabled=false`), исключая любые исходящие UDP-попытки (ICE/STUN) в кластерах с жёстким TCP-only egress. |
 | `MOZ_DISABLE_HTTP3` | `1`, если `RUNNER_DISABLE_HTTP3=true` | Передаётся напрямую Firefox-процессам и гарантирует отключение HTTP/3 ещё до инициализации профиля. |
 | `RUNNER_NETWORK_DIAGNOSTICS` | `["https://bot.sannysoft.com"]` | JSON-массив URL, которые runner проверяет при старте, фиксируя поддержку HTTP/2/HTTP/3 в текущей среде. |

--- a/runner/src/camoufox_runner/sessions.py
+++ b/runner/src/camoufox_runner/sessions.py
@@ -794,7 +794,7 @@ class SessionManager:
         if self._settings.disable_ipv6:
             firefox_prefs["network.dns.disableIPv6"] = True
         if self._settings.disable_http3:
-            firefox_prefs["network.http.http3.enabled"] = False
+            firefox_prefs["network.http.http3.enable"] = False
             firefox_prefs["network.http.http3.enable_0rtt"] = False
             # ``enable_alt_svc`` controls whether HTTP/3 Alt-Svc upgrades are
             # attempted for origins that advertise QUIC support.  Some Firefox


### PR DESCRIPTION
## Summary
- replace usage of the deprecated `network.http.http3.enabled` preference with the correct `network.http.http3.enable`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9570e4200832ab17cc808d3856451