### PR TITLE
Add HTTP/3 toggles and persist Playwright context

### DIFF
--- a/runner/src/camoufox_runner/sessions.py
+++ b/runner/src/camoufox_runner/sessions.py
@@ -794,6 +794,9 @@ class SessionManager:
         if self._settings.disable_ipv6:
             firefox_prefs["network.dns.disableIPv6"] = True
         if self._settings.disable_http3:
+            # Additional toggles to handle older preference aliases that may be
+            # present in various Firefox builds bundled with Playwright.
+            firefox_prefs["network.http.http3.enabled"] = False
             firefox_prefs["network.http.http3.enable"] = False
             firefox_prefs["network.http.http3.enable_0rtt"] = False
             # ``enable_alt_svc`` controls whether HTTP/3 Alt-Svc upgrades are
@@ -819,6 +822,9 @@ class SessionManager:
             "args": opts.get("args") or [],
             "env": env_vars,
         }
+        # Persist the browser context between launches to speed up repeated
+        # connections from the same worker process.
+        config["persistentContext"] = True
         if executable_path := opts.get("executable_path"):
             config["executablePath"] = executable_path
         if prefs := opts.get("firefox_user_prefs"):

--- a/runner/tests/test_sessions.py
+++ b/runner/tests/test_sessions.py
@@ -137,7 +137,9 @@ def test_launch_browser_server_overrides_moz_disable_http3(monkeypatch):
 
         config = captured_config["config"]
         assert config["env"]["MOZ_DISABLE_HTTP3"] == "1"
+        assert config["persistentContext"] is True
         prefs = config["firefoxUserPrefs"]
+        assert prefs["network.http.http3.enabled"] is False
         assert prefs["network.http.http3.enable"] is False
         assert prefs["network.http.http3.enable_alt_svc"] is False
         assert prefs["network.http.http3.alt_svc"] is False


### PR DESCRIPTION
## Summary
- disable additional HTTP/3 preference aliases to cover more Firefox builds
- persist the Playwright browser context across launches for reuse

## Testing
- pytest runner/tests/test_sessions.py

------
https://chatgpt.com/codex/tasks/task_e_68d9f1887374832a8bb8ee109a83635f