### PR TITLE
Default Helm resources to camofleet base name

### DIFF
--- a/control-plane/tests/test_vnc_overrides.py
+++ b/control-plane/tests/test_vnc_overrides.py
@@ -89,8 +89,8 @@ def test_apply_vnc_overrides_matches_helm_defaults() -> None:
         name="worker-vnc",
         url="http://worker-vnc",  # matches the service endpoint rendered by Helm
         supports_vnc=True,
-        vnc_http="http://camofleet-camo-fleet-worker-vnc:6080/vnc/{id}",
-        vnc_ws="ws://camofleet-camo-fleet-worker-vnc:6080/websockify?token={id}",
+        vnc_http="http://camofleet-worker-vnc:6080/vnc/{id}",
+        vnc_ws="ws://camofleet-worker-vnc:6080/websockify?token={id}",
     )
 
     payload = {
@@ -101,10 +101,10 @@ def test_apply_vnc_overrides_matches_helm_defaults() -> None:
     result = apply_vnc_overrides(worker, "session-helm", payload)
 
     assert result["http"] == (
-        "http://camofleet-camo-fleet-worker-vnc:6080/"
+        "http://camofleet-worker-vnc:6080/"
         "vnc/session-helm/vnc.html?path=vnc%2Fwebsockify&target_port=6930"
     )
     assert result["ws"] == (
-        "ws://camofleet-camo-fleet-worker-vnc:6080/"
+        "ws://camofleet-worker-vnc:6080/"
         "websockify?token=session-helm&target_port=6930"
     )

--- a/deploy/helm/camofleet/values.yaml
+++ b/deploy/helm/camofleet/values.yaml
@@ -1,3 +1,5 @@
+nameOverride: camofleet
+
 global:
   imageRegistry: ""
   imagePullSecrets: []

--- a/deploy/traefik/README.md
+++ b/deploy/traefik/README.md
@@ -4,7 +4,7 @@ k3s ships with Traefik installed by default. The manifest in this folder wires t
 
 ## Before you apply the manifest
 
-1. **Install the Helm release first.** Follow `deploy/helm/README.md` to deploy the workloads and Services in the `camofleet` namespace. Если вы переименовали релиз Helm (не `camofleet`), отредактируйте `service.name` в манифесте так, чтобы он совпадал с реальными сервисами (например, `myrelease-camo-fleet-control`).
+1. **Install the Helm release first.** Follow `deploy/helm/README.md` to deploy the workloads and Services in the `camofleet` namespace. Если вы переопределили `nameOverride` или `fullnameOverride`, отредактируйте `service.name` в манифесте так, чтобы он совпадал с реальными сервисами (например, `custom-control`).
 2. **Make sure Traefik knows about TLS for the domain.** By default the manifest expects a certResolver named `letsencrypt`. Adjust the `tls` block in `camofleet-ingressroute.yaml` if your environment differs:
    - **Existing secret.** Replace the `tls` section with `tls: { secretName: camofleet-services-tls }` and create that secret in the `camofleet` namespace:
      ```bash
@@ -38,10 +38,10 @@ kubectl describe ingressroute -n camofleet camofleet
 
 ## What the manifest does
 
-- `/` → `camofleet-camo-fleet-ui:80`
-- `/api` → `camofleet-camo-fleet-control:9000`
-- `/vnc` → `camofleet-camo-fleet-worker-vnc:6080` (контейнер gateway внутри worker отвечает за noVNC)
-- `/websockify` → проксирование на `camofleet-camo-fleet-worker-vnc:6080` без дополнительного префикса, чтобы внешние noVNC WebSocket-URL выглядели как `https://camofleet.services.synestra.tech/websockify?token=...`
+- `/` → `camofleet-ui:80`
+- `/api` → `camofleet-control:9000`
+- `/vnc` → `camofleet-worker-vnc:6080` (контейнер gateway внутри worker отвечает за noVNC)
+- `/websockify` → проксирование на `camofleet-worker-vnc:6080` без дополнительного префикса, чтобы внешние noVNC WebSocket-URL выглядели как `https://camofleet.services.synestra.tech/websockify?token=...`
 
 ## Remove the publication
 

--- a/deploy/traefik/camofleet-ingressroute.yaml
+++ b/deploy/traefik/camofleet-ingressroute.yaml
@@ -13,13 +13,13 @@ spec:
         - name: camofleet-strip-api
           namespace: camofleet
       services:
-        - name: camofleet-camo-fleet-control
+        - name: camofleet-control
           namespace: camofleet
           port: 9000
     - match: Host(`camofleet.services.synestra.tech`) && PathPrefix(`/vnc`)
       kind: Rule
       services:
-        - name: camofleet-camo-fleet-worker-vnc
+        - name: camofleet-worker-vnc
           namespace: camofleet
           port: 6080
     - match: Host(`camofleet.services.synestra.tech`) && PathPrefix(`/websockify`)
@@ -28,14 +28,14 @@ spec:
         - name: camofleet-add-vnc-prefix
           namespace: camofleet
       services:
-        - name: camofleet-camo-fleet-worker-vnc
+        - name: camofleet-worker-vnc
           namespace: camofleet
           port: 6080
     - match: Host(`camofleet.services.synestra.tech`)
       kind: Rule
       priority: 1
       services:
-        - name: camofleet-camo-fleet-ui
+        - name: camofleet-ui
           namespace: camofleet
           port: 80
   tls:


### PR DESCRIPTION
## Summary
- set the Helm chart's default `nameOverride` to `camofleet` to avoid duplicated prefixes in resource names
- update the Traefik manifest and README to reference the new service names and guidance for overrides
- align the VNC override unit test with the renamed default services

## Testing
- `pytest control-plane/tests/test_vnc_overrides.py` *(fails: ModuleNotFoundError: No module named 'camofleet_control')*


------
https://chatgpt.com/codex/tasks/task_e_68da8f5a1514832a8392035c47204f5b